### PR TITLE
Translate the keepalive / holdtime from api to frr

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -108,3 +108,49 @@ jobs:
         env:
           TAGS: ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}
           COSIGN_EXPERIMENTAL: 1
+  release-charts:
+    needs: [publish-images]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Fetch entire history. Required for chart-releaser; see https://github.com/helm/chart-releaser-action/issues/13#issuecomment-602063896
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Chart releaser
+        if: startsWith(github.ref, 'refs/tags/v') # we craft releases only for tags
+        run: |
+          # Download chart releaser
+          curl -sSLo cr.tar.gz "https://github.com/helm/chart-releaser/releases/download/v1.4.0/chart-releaser_1.4.0_linux_amd64.tar.gz"
+          tar -xzf cr.tar.gz
+          rm -f cr.tar.gz
+          repo=$(basename "$GITHUB_REPOSITORY")
+          owner=$(dirname "$GITHUB_REPOSITORY")
+          tag="${GITHUB_REF_NAME:1}"
+
+          exists=$(curl -s -H "Accept: application/vnd.github.v3+json" https://github.com/$GITHUB_REPOSITORY/releases/tag/$repo-chart-$tag -w %{http_code} -o /dev/null)
+          if [[ $exists != "200" ]]; then
+            echo "Creating release..."
+            # package chart
+            ./cr package charts/$repo
+            # upload chart to github releases
+            ./cr upload \
+                --owner "$owner" \
+                --git-repo "$repo" \
+                --release-name-template "{{ .Name }}-chart-{{ .Version }}" \
+                --token "${{ secrets.GITHUB_TOKEN }}"
+            # Update index and push to github pages
+            ./cr index \
+                --owner "$owner" \
+                --git-repo "$repo" \
+                --index-path index.yaml \
+                --release-name-template "{{ .Name }}-chart-{{ .Version }}" \
+                --push
+          else
+            echo "Release already exists"
+          fi

--- a/api/v1beta1/frrconfiguration_types.go
+++ b/api/v1beta1/frrconfiguration_types.go
@@ -100,10 +100,12 @@ type Neighbor struct {
 	PasswordSecret v1.SecretReference `json:"password,omitempty"`
 
 	// Requested BGP hold time, per RFC4271.
+	// +kubebuilder:default:="90s"
 	// +optional
 	HoldTime metav1.Duration `json:"holdTime,omitempty"`
 
 	// Requested BGP keepalive time, per RFC4271.
+	// +kubebuilder:default:="30s"
 	// +optional
 	KeepaliveTime metav1.Duration `json:"keepaliveTime,omitempty"`
 

--- a/charts/frr-k8s/charts/crds/templates/crds.yaml
+++ b/charts/frr-k8s/charts/crds/templates/crds.yaml
@@ -146,9 +146,11 @@ spec:
                                 description: To set if the BGPPeer is multi-hops away.
                                 type: boolean
                               holdTime:
+                                default: 90s
                                 description: Requested BGP hold time, per RFC4271.
                                 type: string
                               keepaliveTime:
+                                default: 30s
                                 description: Requested BGP keepalive time, per RFC4271.
                                 type: string
                               password:

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -161,9 +161,11 @@ spec:
                                 description: To set if the BGPPeer is multi-hops away.
                                 type: boolean
                               holdTime:
+                                default: 90s
                                 description: Requested BGP hold time, per RFC4271.
                                 type: string
                               keepaliveTime:
+                                default: 30s
                                 description: Requested BGP keepalive time, per RFC4271.
                                 type: string
                               password:

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -161,9 +161,11 @@ spec:
                                 description: To set if the BGPPeer is multi-hops away.
                                 type: boolean
                               holdTime:
+                                default: 90s
                                 description: Requested BGP hold time, per RFC4271.
                                 type: string
                               keepaliveTime:
+                                default: 30s
                                 description: Requested BGP keepalive time, per RFC4271.
                                 type: string
                               password:

--- a/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
@@ -146,9 +146,11 @@ spec:
                                 description: To set if the BGPPeer is multi-hops away.
                                 type: boolean
                               holdTime:
+                                default: 90s
                                 description: Requested BGP hold time, per RFC4271.
                                 type: string
                               keepaliveTime:
+                                default: 30s
                                 description: Requested BGP keepalive time, per RFC4271.
                                 type: string
                               password:

--- a/e2etests/go.mod
+++ b/e2etests/go.mod
@@ -5,7 +5,7 @@ go 1.19
 replace (
 	github.com/metallb/frrk8s => ../
 	github.com/onsi/ginkgo/v2 => github.com/onsi/ginkgo/v2 v2.11.0
-	go.universe.tf/e2etest => github.com/metallb/metallb/e2etest v0.0.0-20230719075116-22ffd63a2942
+	go.universe.tf/e2etest => github.com/metallb/metallb/e2etest v0.0.0-20231011082735-b97649a34a4c
 	k8s.io/api => k8s.io/api v0.26.0
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.26.0
 	k8s.io/apimachinery => k8s.io/apimachinery v0.26.0

--- a/e2etests/go.sum
+++ b/e2etests/go.sum
@@ -226,8 +226,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metallb/metallb/e2etest v0.0.0-20230719075116-22ffd63a2942 h1:KHKjIaQSPXxqSRMf7KwRGSigM5OdrmGsTZUjBCCYEmI=
-github.com/metallb/metallb/e2etest v0.0.0-20230719075116-22ffd63a2942/go.mod h1:pvpDmNSSuGzhAF32B9Rsf8cl+9XiAMq0fRMaWbJsWAo=
+github.com/metallb/metallb/e2etest v0.0.0-20231011082735-b97649a34a4c h1:nBvXZonPdFKCwx8UFSQQdB+eI9HpudGm2DYzq5tUSKQ=
+github.com/metallb/metallb/e2etest v0.0.0-20231011082735-b97649a34a4c/go.mod h1:KEE9slBrrnF8XYHcxe5/dvYskqo0Z3OJtr+ua7iv1hw=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721 h1:RlZweED6sbSArvlE924+mUcZuXKLBHA35U7LN621Bws=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721/go.mod h1:Ickgr2WtCLZ2MDGd4Gr0geeCH5HybhRJbonOgQpvSxc=
 github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=

--- a/e2etests/go.work.sum
+++ b/e2etests/go.work.sum
@@ -263,8 +263,8 @@ github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118/go.mod h1:ZFUnHI
 github.com/mdlayher/ndp v0.0.0-20200602162440-17ab9e3e5567/go.mod h1:32w/5dDZWVSEOxyniAgKK4d7dHTuO6TCxWmUznQe3f8=
 github.com/mdlayher/packet v1.0.0/go.mod h1:eE7/ctqDhoiRhQ44ko5JZU2zxB88g+JH/6jmnjzPjOU=
 github.com/mdlayher/socket v0.2.1/go.mod h1:QLlNPkFR88mRUNQIzRBMfXxwKal8H7u1h3bL1CV+f0E=
-github.com/metallb/metallb/e2etest v0.0.0-20230719075116-22ffd63a2942 h1:KHKjIaQSPXxqSRMf7KwRGSigM5OdrmGsTZUjBCCYEmI=
-github.com/metallb/metallb/e2etest v0.0.0-20230719075116-22ffd63a2942/go.mod h1:pvpDmNSSuGzhAF32B9Rsf8cl+9XiAMq0fRMaWbJsWAo=
+github.com/metallb/metallb/e2etest v0.0.0-20231011082735-b97649a34a4c h1:nBvXZonPdFKCwx8UFSQQdB+eI9HpudGm2DYzq5tUSKQ=
+github.com/metallb/metallb/e2etest v0.0.0-20231011082735-b97649a34a4c/go.mod h1:KEE9slBrrnF8XYHcxe5/dvYskqo0Z3OJtr+ua7iv1hw=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=

--- a/e2etests/tests/session.go
+++ b/e2etests/tests/session.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package tests
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+
+	frrk8sv1beta1 "github.com/metallb/frrk8s/api/v1beta1"
+	"github.com/metallb/frrk8stests/pkg/config"
+	"github.com/metallb/frrk8stests/pkg/dump"
+	"github.com/metallb/frrk8stests/pkg/infra"
+	"github.com/metallb/frrk8stests/pkg/k8s"
+	. "github.com/onsi/gomega"
+	"go.universe.tf/e2etest/pkg/frr"
+	frrconfig "go.universe.tf/e2etest/pkg/frr/config"
+	"go.universe.tf/metallb/e2etest/pkg/executor"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+
+	"k8s.io/kubernetes/test/e2e/framework"
+	admissionapi "k8s.io/pod-security-admission/api"
+)
+
+var _ = ginkgo.Describe("Advertisement", func() {
+	var f *framework.Framework
+	var cs clientset.Interface
+
+	defer ginkgo.GinkgoRecover()
+	clientconfig, err := framework.LoadConfig()
+	framework.ExpectNoError(err)
+	updater, err := config.NewUpdater(clientconfig)
+	framework.ExpectNoError(err)
+	reporter := dump.NewK8sReporter(framework.TestContext.KubeConfig, k8s.FRRK8sNamespace)
+
+	f = framework.NewDefaultFramework("bgpfrr")
+	f.NamespacePodSecurityEnforceLevel = admissionapi.LevelPrivileged
+
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentSpecReport().Failed() {
+			testName := ginkgo.CurrentSpecReport().LeafNodeText
+			dump.K8sInfo(testName, reporter)
+			dump.BGPInfo(testName, infra.FRRContainers, f.ClientSet, f)
+		}
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Clearing any previous configuration")
+
+		for _, c := range infra.FRRContainers {
+			err := c.UpdateBGPConfigFile(frrconfig.Empty)
+			framework.ExpectNoError(err)
+		}
+		err := updater.Clean()
+		framework.ExpectNoError(err)
+		cs = f.ClientSet
+	})
+
+	ginkgo.Context("Session parameters", func() {
+		ginkgo.It("are set correctly", func() {
+			config := frrk8sv1beta1.FRRConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: frrk8sv1beta1.FRRConfigurationSpec{
+					BGP: frrk8sv1beta1.BGPConfig{
+						Routers: []frrk8sv1beta1.Router{
+							{
+								ASN: infra.FRRK8sASN,
+								Neighbors: []frrk8sv1beta1.Neighbor{
+									{
+										ASN:     1234,
+										Address: "192.168.1.1",
+										HoldTime: metav1.Duration{
+											Duration: 120 * time.Second,
+										},
+										KeepaliveTime: metav1.Duration{
+											Duration: 40 * time.Second,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			err = updater.Update([]corev1.Secret{}, config)
+			framework.ExpectNoError(err)
+
+			pods, err := k8s.FRRK8sPods(cs)
+			framework.ExpectNoError(err)
+
+			for _, pod := range pods {
+				podExec := executor.ForPod(pod.Namespace, pod.Name, "frr")
+				Eventually(func() error {
+					neighbors, err := frr.NeighborsInfo(podExec)
+					if err != nil {
+						return err
+					}
+					if len(neighbors) != 1 {
+						return fmt.Errorf("expected 1 neighbor, got %d", len(neighbors))
+					}
+					if neighbors[0].ConfiguredHoldTime != 120000 {
+						return fmt.Errorf("expected hold time to be 120000, got %d", neighbors[0].ConfiguredHoldTime)
+					}
+					if neighbors[0].ConfiguredKeepAliveTime != 40000 {
+						return fmt.Errorf("expected hold time to be 40000, got %d", neighbors[0].ConfiguredKeepAliveTime)
+					}
+					return nil
+				}, 2*time.Minute, time.Second).ShouldNot(HaveOccurred())
+			}
+		})
+	})
+})

--- a/internal/controller/api_to_config.go
+++ b/internal/controller/api_to_config.go
@@ -118,7 +118,7 @@ func routerToFRRConfig(r v1beta1.Router, secrets map[string]corev1.Secret, bfdPr
 	}
 
 	for _, n := range r.Neighbors {
-		frrNeigh, err := neighborToFRR(n, res.IPV4Prefixes, res.IPV6Prefixes, secrets, bfdProfiles)
+		frrNeigh, err := neighborToFRR(n, res.IPV4Prefixes, res.IPV6Prefixes, r.VRF, secrets, bfdProfiles)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process neighbor %s for router %d-%s: %w", neighborName(n.ASN, n.Address), r.ASN, r.VRF, err)
 		}
@@ -128,7 +128,7 @@ func routerToFRRConfig(r v1beta1.Router, secrets map[string]corev1.Secret, bfdPr
 	return res, nil
 }
 
-func neighborToFRR(n v1beta1.Neighbor, ipv4Prefixes, ipv6Prefixes []string, passwordSecrets map[string]corev1.Secret, bfdProfiles map[string]*frr.BFDProfile) (*frr.NeighborConfig, error) {
+func neighborToFRR(n v1beta1.Neighbor, ipv4Prefixes, ipv6Prefixes []string, routerVRF string, passwordSecrets map[string]corev1.Secret, bfdProfiles map[string]*frr.BFDProfile) (*frr.NeighborConfig, error) {
 	neighborFamily, err := ipfamily.ForAddresses(n.Address)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find ipfamily for %s, %w", n.Address, err)
@@ -144,6 +144,7 @@ func neighborToFRR(n v1beta1.Neighbor, ipv4Prefixes, ipv6Prefixes []string, pass
 		IPFamily:     neighborFamily,
 		EBGPMultiHop: n.EBGPMultiHop,
 		BFDProfile:   n.BFDProfile,
+		VRFName:      routerVRF,
 	}
 
 	holdTime := n.HoldTime.Duration

--- a/internal/controller/api_to_config_test.go
+++ b/internal/controller/api_to_config_test.go
@@ -187,6 +187,7 @@ func TestConversion(t *testing.T) {
 								ASN:      65014,
 								Addr:     "2001:db8::4",
 								Port:     179,
+								VRFName:  "vrf2",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{},
 									PrefixesV6: []frr.OutgoingFilter{},
@@ -312,6 +313,7 @@ func TestConversion(t *testing.T) {
 								ASN:      65031,
 								Addr:     "192.0.2.16",
 								Port:     179,
+								VRFName:  "vrf1",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{},
 									PrefixesV6: []frr.OutgoingFilter{},
@@ -1298,6 +1300,7 @@ func TestConversion(t *testing.T) {
 								ASN:      65017,
 								Addr:     "192.0.2.7",
 								Port:     179,
+								VRFName:  "vrf2",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
 										{
@@ -1318,6 +1321,7 @@ func TestConversion(t *testing.T) {
 								ASN:      65014,
 								Addr:     "2001:db8::4",
 								Port:     179,
+								VRFName:  "vrf2",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
 										{
@@ -1451,6 +1455,7 @@ func TestConversion(t *testing.T) {
 								ASN:      65017,
 								Addr:     "192.0.2.7",
 								Port:     179,
+								VRFName:  "vrf2",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{},
 									PrefixesV6: []frr.OutgoingFilter{},
@@ -1466,6 +1471,7 @@ func TestConversion(t *testing.T) {
 								ASN:      65014,
 								Addr:     "2001:db8::4",
 								Port:     179,
+								VRFName:  "vrf2",
 								Password: "password2",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{},

--- a/internal/controller/api_to_config_test.go
+++ b/internal/controller/api_to_config_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	v1beta1 "github.com/metallb/frrk8s/api/v1beta1"
@@ -14,6 +15,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestConversion(t *testing.T) {
@@ -40,6 +42,12 @@ func TestConversion(t *testing.T) {
 											ASN:     65002,
 											Address: "192.0.2.2",
 											Port:    179,
+											KeepaliveTime: metav1.Duration{
+												Duration: 20 * time.Second,
+											},
+											HoldTime: metav1.Duration{
+												Duration: 40 * time.Second,
+											},
 										},
 									},
 									VRF:      "",
@@ -58,11 +66,13 @@ func TestConversion(t *testing.T) {
 						RouterID: "192.0.2.1",
 						Neighbors: []*frr.NeighborConfig{
 							{
-								IPFamily: ipfamily.IPv4,
-								Name:     "65002@192.0.2.2",
-								ASN:      65002,
-								Addr:     "192.0.2.2",
-								Port:     179,
+								IPFamily:      ipfamily.IPv4,
+								Name:          "65002@192.0.2.2",
+								ASN:           65002,
+								Addr:          "192.0.2.2",
+								Port:          179,
+								KeepaliveTime: 20,
+								HoldTime:      40,
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{},
 									PrefixesV6: []frr.OutgoingFilter{},
@@ -1846,6 +1856,39 @@ func TestConversion(t *testing.T) {
 				},
 			},
 			err: nil,
+		},
+		{
+			name: "HoldTime bigger than keepalive time",
+			fromK8s: []v1beta1.FRRConfiguration{
+				{
+					Spec: v1beta1.FRRConfigurationSpec{
+						BGP: v1beta1.BGPConfig{
+							Routers: []v1beta1.Router{
+								{
+									ASN: 65001,
+									ID:  "192.0.2.1",
+									Neighbors: []v1beta1.Neighbor{
+										{
+											ASN:     65002,
+											Address: "192.0.2.2",
+											Port:    179,
+											KeepaliveTime: metav1.Duration{
+												Duration: 50 * time.Second,
+											},
+											HoldTime: metav1.Duration{
+												Duration: 40 * time.Second,
+											},
+										},
+									},
+									VRF: "",
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: map[string]v1.Secret{},
+			err:     errors.New(`failed to process neighbor 65002@192.0.2.2 for router 65001-: invalid keepaliveTime {"50s"}`),
 		},
 	}
 


### PR DESCRIPTION
Those fields were missing. Also, we do validate their values as we did in metallb.

Note: this requires https://github.com/metallb/metallb/pull/2104 to make the tests compile