### PR TITLE
Release automation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
           make manifests
           make generate-all-in-one
           make checkuncommitted
-      
+
       - name: Helm doc generate
         uses: docker://jnorwood/helm-docs:v1.10.0
 
@@ -90,7 +90,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          tags: quay.io/metallb/frr-k8s:dev-amd64
+          tags: quay.io/metallb/frr-k8s:dev
           file: Dockerfile
           outputs: type=docker,dest=/tmp/frrk8s.tar
           cache-from: type=gha
@@ -140,7 +140,7 @@ jobs:
         run: |
           MAKE_RULE="deploy-with-prometheus"
           if [ ${{ matrix.deployment }} = "helm" ]; then MAKE_RULE="deploy-helm"; fi
-          LOGLEVEL=debug IP_FAMILY="${{ matrix.ip-family }}" IMG_TAG=dev-amd64 make $MAKE_RULE
+          LOGLEVEL=debug IP_FAMILY="${{ matrix.ip-family }}" make $MAKE_RULE
           mkdir -p /tmp/kind_logs/
 
       - name: E2E

--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -1,0 +1,39 @@
+# Release process
+
+## Preparing the branch
+
+Checkout the release branch and cherry pick the relevant commits:
+
+```bash
+git checkout v0.9
+git cherry-pick -x f1f86ed658c1e8a6f90f967ed94881d61476b4c0
+git push
+```
+
+## Finalize the release notes
+
+All release notes are always written on the main branch in the `RELEASE_NOTES.md` file, and copied into release branches in a later step. Point out all new features and actions required by users. If there are very notable bugfixes (e.g. security issues, long-term pain point resolved), point those out as well.
+
+For each new release, a section like `## Release vX.Y.Z` must be added.
+
+To get a list of contributors to the release, run `git log --format="%aN" $(git merge-base CUR-BRANCH PREV-TAG)..CUR-BRANCH | sort -u | tr '\n' ',' | sed -e 's/,/, /g'`. CUR-BRANCH is main if you’re making a minor release (e.g. 0.9.0), or the release branch for the current version if you’re making a patch release (e.g. v0.8 if you’re making v0.8.4). PREV-TAG is the release tag name for the last release (e.g. if you’re preparing 0.8.4, PREV-TAG is v0.8.3. Also think about whether there were significant contributions that weren’t in the form of a commit, and include those people as well. It’s better to err on the side of being too thankful!
+
+Commit the finalized release notes.
+
+## Clean the working directory
+
+The release script only works if the Git working directory is completely clean: no pending modifications, no untracked files, nothing. Make sure everything is clean, or run the release from a fresh checkout.
+
+The release script will abort if the working directory isn’t right.
+
+## Run the release script
+Run `FRRK8S_VERSION="X.Y.Z" make cutrelease` from the main branch. This will create the appropriate branches, commits and tags in your local repository.
+
+## Push the new artifacts
+Run git push --tags origin main `vX.Y`. This will push all pending changes both in main and the release branch, as well as the new tag for the release.
+
+## Wait for the image repositories to update
+When you pushed, GitHub actions kicked off a set of image builds for the new tag. You need to wait for these images to be pushed live before creating a new release. Check on quay.io that the tagget version exists.
+
+## Create a new release on github
+By default, new tags show up de-emphasized in the list of releases. Create a new release attached to the tag you just pushed. Make the description point to the release notes on the website.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,11 @@
 
-# Image URL to use all building/pushing image targets
-IMG_TAG ?= dev
+ifeq (,$(FRRK8S_VERSION))
+IMG_TAG="dev"
+GOBIN=$(shell go env GOPATH)/bin
+else
+IMG_TAG=v${FRRK8S_VERSION}
+endif
+
 IMG_BASE ?= quay.io/metallb/frr-k8s
 IMG ?= ${IMG_BASE}:${IMG_TAG}
 NAMESPACE ?= "frr-k8s-system"
@@ -262,4 +267,13 @@ generate-all-in-one: manifests kustomize ## Create manifests
 
 .PHONY: helm-docs
 helm-docs:
-	docker run --rm -v $(git rev-parse --show-toplevel):/app -w /app jnorwood/helm-docs:$(HELM_DOCS_VERSION) helm-docs
+	docker run --rm -v $$(pwd):/app -w /app jnorwood/helm-docs:$(HELM_DOCS_VERSION) helm-docs
+
+.PHONY: bumpversion
+bumpversion:
+	hack/release/pre_bump.sh
+	hack/release/bumpversion.sh
+
+.PHONY: cutrelease
+cutrelease: bumpversion generate-all-in-one helm-docs
+	hack/release/release.sh

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,1 @@
+# FRRK8s Release Notes

--- a/hack/release/bumpversion.sh
+++ b/hack/release/bumpversion.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+if [ -z "$FRRK8S_VERSION" ]; then
+    echo "must set the FRRK8S_VERSION environment variable"
+    exit -1
+fi
+
+sed -i "s/newTag:.*$/newTag: v$FRRK8S_VERSION/" config/frr-k8s/kustomization.yaml
+
+sed -i "s/version:.*$/version: $FRRK8S_VERSION/" charts/frr-k8s/Chart.yaml
+sed -i "s/appVersion:.*$/appVersion: v$FRRK8S_VERSION/" charts/frr-k8s/Chart.yaml
+sed -i "s/version:.*$/version: $FRRK8S_VERSION/" charts/frr-k8s/charts/crds/Chart.yaml
+sed -i "s/appVersion:.*$/appVersion: v$FRRK8S_VERSION/" charts/frr-k8s/charts/crds/Chart.yaml
+helm dep update charts/frr-k8s
+
+sed -i "s/version.*release cutting.*$/version = \"v$FRRK8S_VERSION\"/" internal/version/version.go
+gofmt -w internal/version/version.go

--- a/hack/release/pre_bump.sh
+++ b/hack/release/pre_bump.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+
+if [ -z "$FRRK8S_VERSION" ]; then
+    echo "must set the FRRK8S_VERSION environment variable"
+    exit -1
+fi
+
+gitstatus=$(git status --porcelain)
+if [ -n "$gitstatus" ]; then
+	echo "uncommitted changes"
+	echo $gitstatus
+	exit 1
+fi
+
+
+VERSION="$FRRK8S_VERSION"
+VERSION="${VERSION#[vV]}"
+VERSION_MAJOR="${VERSION%%\.*}"
+VERSION_MINOR="${VERSION#*.}"
+VERSION_MINOR="${VERSION_MINOR%.*}"
+VERSION_PATCH="${VERSION##*.}"
+
+git checkout main
+
+if ! grep -q "## Release v$FRRK8S_VERSION" RELEASE_NOTES.md; then
+  echo "Version $FRRK8S_VERSION missing from release notes"
+  exit 1
+fi
+
+BRANCH_NAME="v$VERSION_MAJOR.$VERSION_MINOR"
+if [ $minor = "0" ]; then # patch release
+	git checkout -b $BRANCH_NAME
+else
+	git checkout $BRANCH_NAME
+fi
+
+git checkout main -- RELEASE_NOTES.md

--- a/hack/release/release.sh
+++ b/hack/release/release.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+if [ -z "$FRRK8S_VERSION" ]; then
+    echo "must set the FRRK8S_VERSION environment variable"
+    exit -1
+fi
+
+
+git commit -a -m "Automated update for release v$FRRK8S_VERSION"
+git tag "v$FRRK8S_VERSION" -m 'See the release notes for details:\n\nhttps://raw.githubusercontent.com/metallb/frr-k8s/main/RELEASE_NOTES.md'
+git checkout main


### PR DESCRIPTION
- Add a CI step to create the helm chart
- Add a makefile rule to automate the release process (with versioning the tags around the manifests)
- Create an empty release notes file