### PR TITLE
FRR configuration: force the sequence number from the template

### DIFF
--- a/internal/frr/config.go
+++ b/internal/frr/config.go
@@ -119,17 +119,14 @@ type OutgoingFilter struct {
 // templateConfig uses the template library to template
 // 'globalConfigTemplate' using 'data'.
 func templateConfig(data interface{}) (string, error) {
-	i := 0
-	currentCounterName := ""
+	counterMap := map[string]int{}
 	t, err := template.New("frr.tmpl").Funcs(
 		template.FuncMap{
 			"counter": func(counterName string) int {
-				if currentCounterName != counterName {
-					currentCounterName = counterName
-					i = 0
-				}
-				i++
-				return i
+				counter := counterMap[counterName]
+				counter++
+				counterMap[counterName] = counter
+				return counter
 			},
 			"frrIPFamily": func(ipFamily ipfamily.Family) string {
 				if ipFamily == "ipv6" {

--- a/internal/frr/templates/filters.tmpl
+++ b/internal/frr/templates/filters.tmpl
@@ -1,5 +1,6 @@
 {{- define "localpreffilter" -}}
-{{frrIPFamily .advertisement.IPFamily}} prefix-list {{localPrefPrefixList .neighbor .advertisement.LocalPref}} permit {{.advertisement.Prefix}}
+{{$localPrefixListName :=localPrefPrefixList .neighbor .advertisement.LocalPref}}
+{{frrIPFamily .advertisement.IPFamily}} prefix-list {{$localPrefixListName}} seq {{counter $localPrefixListName}} permit {{.advertisement.Prefix}}
 route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
   match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{localPrefPrefixList .neighbor .advertisement.LocalPref}}
   set local-preference {{.advertisement.LocalPref}}
@@ -7,7 +8,8 @@ route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
 {{- end -}}
 
 {{- define "communityfilter" -}}
-{{frrIPFamily .advertisement.IPFamily}} prefix-list {{communityPrefixList .neighbor .community}} permit {{.advertisement.Prefix}}
+{{$communityPrefixlistName :=communityPrefixList .neighbor .community}}
+{{frrIPFamily .advertisement.IPFamily}} prefix-list {{$communityPrefixlistName}} seq {{counter $communityPrefixlistName}} permit {{.advertisement.Prefix}}
 route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
   match {{frrIPFamily .advertisement.IPFamily}} address prefix-list {{communityPrefixList .neighbor .community}}
   set community {{.community}} additive
@@ -43,7 +45,8 @@ route-map {{.neighbor.ID}}-out permit {{counter .neighbor.ID}}
 {{template "largecommunityfilter" dict "advertisement" $a "neighbor" $.neighbor "largecommunity" $lc}}
 {{- end }}
 {{/* this advertisement is allowed to the specific neighbor  */}}
-{{frrIPFamily $a.IPFamily}} prefix-list {{allowedPrefixList $.neighbor}} permit {{$a.Prefix}}
+{{$plistName:=allowedPrefixList $.neighbor}}
+{{frrIPFamily $a.IPFamily}} prefix-list {{$plistName}} seq {{counter $plistName}} permit {{$a.Prefix}}
 {{- end }}
 
 route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
@@ -53,23 +56,25 @@ route-map {{$.neighbor.ID}}-out permit {{counter $.neighbor.ID}}
 
 {{/* If the neighbor does not have an advertisement, we need to add a prefix to deny
 for when we have a prefix but a given peer is not selected for any prefixes */}}
-{{- if not .neighbor.Outgoing.PrefixesV4 }}
-ip prefix-list {{allowedPrefixList $.neighbor }} deny any
+{{$plistName:=allowedPrefixList $.neighbor}}
+{{- if not .neighbor.Outgoing.PrefixesV4}}
+ip prefix-list {{$plistName}} seq {{counter $plistName}} deny any
 {{- end }}
-{{- if not .neighbor.Outgoing.PrefixesV6 }}
-ipv6 prefix-list {{allowedPrefixList $.neighbor}} deny any
-{{- end -}}
+{{- if not .neighbor.Outgoing.PrefixesV6}}
+ipv6 prefix-list {{$plistName}} seq {{counter $plistName}} deny any
+{{- end }}
 
 {{/* filtering incoming prefixes */}}
+{{$plistName:=allowedIncomingList $.neighbor}}
 {{ range $i := .neighbor.Incoming.AllPrefixes }}
-{{frrIPFamily $i.IPFamily}} prefix-list {{allowedIncomingList $.neighbor}} permit {{$i.Prefix}}
+{{frrIPFamily $i.IPFamily}} prefix-list {{$plistName}} seq {{counter $plistName}} permit {{$i.Prefix}}
 {{- end }}
 
 {{ if not .neighbor.Incoming.PrefixesV4 }}
-ip prefix-list {{allowedIncomingList $.neighbor }} deny any
+ip prefix-list {{$plistName}} seq {{counter $plistName}} deny any
 {{- end }}
 {{ if not .neighbor.Incoming.PrefixesV6 }}
-ipv6 prefix-list {{allowedIncomingList $.neighbor}} deny any
+ipv6 prefix-list {{$plistName}} seq {{counter $plistName}} deny any
 {{- end -}}
 
 {{ if .neighbor.Incoming.All }}

--- a/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6.golden
+++ b/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6.golden
@@ -6,7 +6,8 @@ ipv6 nht resolve-via-default
 
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
 
 route-map 192.168.1.2-out permit 1
   match ip address prefix-list 192.168.1.2-pl-ipv4
@@ -14,13 +15,17 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4
@@ -28,7 +33,8 @@ route-map 192.168.1.2-in permit 4
 
 
 
-ipv6 prefix-list 2001:db8::1-pl-ipv6 permit 2001:db8:abcd::/48
+
+ipv6 prefix-list 2001:db8::1-pl-ipv6 seq 1 permit 2001:db8:abcd::/48
 
 route-map 2001:db8::1-out permit 1
   match ip address prefix-list 2001:db8::1-pl-ipv6
@@ -36,13 +42,17 @@ route-map 2001:db8::1-out permit 2
   match ipv6 address prefix-list 2001:db8::1-pl-ipv6
 
 
-ip prefix-list 2001:db8::1-pl-ipv6 deny any
+
+ip prefix-list 2001:db8::1-pl-ipv6 seq 2 deny any
 
 
 
-ip prefix-list 2001:db8::1-inpl-ipv6 deny any
 
-ipv6 prefix-list 2001:db8::1-inpl-ipv6 deny any
+
+
+ip prefix-list 2001:db8::1-inpl-ipv6 seq 1 deny any
+
+ipv6 prefix-list 2001:db8::1-inpl-ipv6 seq 2 deny any
 route-map 2001:db8::1-in permit 3
   match ip address prefix-list 2001:db8::1-inpl-ipv6
 route-map 2001:db8::1-in permit 4

--- a/internal/frr/testdata/TestMultipleRoutersMultipleNeighs.golden
+++ b/internal/frr/testdata/TestMultipleRoutersMultipleNeighs.golden
@@ -6,7 +6,8 @@ ipv6 nht resolve-via-default
 
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
 
 route-map 192.168.1.2-out permit 1
   match ip address prefix-list 192.168.1.2-pl-ipv4
@@ -14,13 +15,17 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4
@@ -28,7 +33,8 @@ route-map 192.168.1.2-in permit 4
 
 
 
-ipv6 prefix-list 2001:db8::1-pl-ipv6 permit 2001:db8:abcd::/48
+
+ipv6 prefix-list 2001:db8::1-pl-ipv6 seq 1 permit 2001:db8:abcd::/48
 
 route-map 2001:db8::1-out permit 1
   match ip address prefix-list 2001:db8::1-pl-ipv6
@@ -36,13 +42,17 @@ route-map 2001:db8::1-out permit 2
   match ipv6 address prefix-list 2001:db8::1-pl-ipv6
 
 
-ip prefix-list 2001:db8::1-pl-ipv6 deny any
+
+ip prefix-list 2001:db8::1-pl-ipv6 seq 2 deny any
 
 
 
-ip prefix-list 2001:db8::1-inpl-ipv6 deny any
 
-ipv6 prefix-list 2001:db8::1-inpl-ipv6 deny any
+
+
+ip prefix-list 2001:db8::1-inpl-ipv6 seq 1 deny any
+
+ipv6 prefix-list 2001:db8::1-inpl-ipv6 seq 2 deny any
 route-map 2001:db8::1-in permit 3
   match ip address prefix-list 2001:db8::1-inpl-ipv6
 route-map 2001:db8::1-in permit 4
@@ -50,7 +60,8 @@ route-map 2001:db8::1-in permit 4
 
 
 
-ip prefix-list 192.170.1.2-pl-ipv4 permit 192.171.1.0/24
+
+ip prefix-list 192.170.1.2-pl-ipv4 seq 1 permit 192.171.1.0/24
 
 route-map 192.170.1.2-out permit 1
   match ip address prefix-list 192.170.1.2-pl-ipv4
@@ -58,13 +69,17 @@ route-map 192.170.1.2-out permit 2
   match ipv6 address prefix-list 192.170.1.2-pl-ipv4
 
 
-ipv6 prefix-list 192.170.1.2-pl-ipv4 deny any
+
+ipv6 prefix-list 192.170.1.2-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.170.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.170.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.170.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.170.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.170.1.2-in permit 3
   match ip address prefix-list 192.170.1.2-inpl-ipv4
 route-map 192.170.1.2-in permit 4
@@ -72,7 +87,8 @@ route-map 192.170.1.2-in permit 4
 
 
 
-ipv6 prefix-list 2001:db9::1-pl-ipv6 permit 2001:db9:abcd::/48
+
+ipv6 prefix-list 2001:db9::1-pl-ipv6 seq 1 permit 2001:db9:abcd::/48
 
 route-map 2001:db9::1-out permit 1
   match ip address prefix-list 2001:db9::1-pl-ipv6
@@ -80,13 +96,17 @@ route-map 2001:db9::1-out permit 2
   match ipv6 address prefix-list 2001:db9::1-pl-ipv6
 
 
-ip prefix-list 2001:db9::1-pl-ipv6 deny any
+
+ip prefix-list 2001:db9::1-pl-ipv6 seq 2 deny any
 
 
 
-ip prefix-list 2001:db9::1-inpl-ipv6 deny any
 
-ipv6 prefix-list 2001:db9::1-inpl-ipv6 deny any
+
+
+ip prefix-list 2001:db9::1-inpl-ipv6 seq 1 deny any
+
+ipv6 prefix-list 2001:db9::1-inpl-ipv6 seq 2 deny any
 route-map 2001:db9::1-in permit 3
   match ip address prefix-list 2001:db9::1-inpl-ipv6
 route-map 2001:db9::1-in permit 4

--- a/internal/frr/testdata/TestSingleSession
+++ b/internal/frr/testdata/TestSingleSession
@@ -6,10 +6,12 @@ ipv6 nht resolve-via-default
 
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.170.1.0/22
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 2 permit 192.170.1.0/22
 
 route-map 192.168.1.2-out permit 1
   match ip address prefix-list 192.168.1.2-pl-ipv4
@@ -17,13 +19,17 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 3 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4

--- a/internal/frr/testdata/TestSingleSession.golden
+++ b/internal/frr/testdata/TestSingleSession.golden
@@ -6,10 +6,12 @@ ipv6 nht resolve-via-default
 
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.170.1.0/22
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 2 permit 192.170.1.0/22
 
 route-map 192.168.1.2-out permit 1
   match ip address prefix-list 192.168.1.2-pl-ipv4
@@ -17,13 +19,17 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 3 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4

--- a/internal/frr/testdata/TestSingleSessionBFD.golden
+++ b/internal/frr/testdata/TestSingleSessionBFD.golden
@@ -11,14 +11,18 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4

--- a/internal/frr/testdata/TestSingleSessionWithEBGPMultihop.golden
+++ b/internal/frr/testdata/TestSingleSessionWithEBGPMultihop.golden
@@ -6,10 +6,12 @@ ipv6 nht resolve-via-default
 
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.170.1.0/22
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 2 permit 192.170.1.0/22
 
 route-map 192.168.1.2-out permit 1
   match ip address prefix-list 192.168.1.2-pl-ipv4
@@ -17,13 +19,17 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 3 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4

--- a/internal/frr/testdata/TestSingleSessionWithEBGPMultihopAndExtras.golden
+++ b/internal/frr/testdata/TestSingleSessionWithEBGPMultihopAndExtras.golden
@@ -6,10 +6,12 @@ ipv6 nht resolve-via-default
 
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.170.1.0/22
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 2 permit 192.170.1.0/22
 
 route-map 192.168.1.2-out permit 1
   match ip address prefix-list 192.168.1.2-pl-ipv4
@@ -17,13 +19,17 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 3 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4

--- a/internal/frr/testdata/TestSingleSessionWithIPv6SingleHop.golden
+++ b/internal/frr/testdata/TestSingleSessionWithIPv6SingleHop.golden
@@ -6,7 +6,8 @@ ipv6 nht resolve-via-default
 
 
 
-ipv6 prefix-list 2001:db8::1-pl-ipv6 permit 2001:db8:abcd::/48
+
+ipv6 prefix-list 2001:db8::1-pl-ipv6 seq 1 permit 2001:db8:abcd::/48
 
 route-map 2001:db8::1-out permit 1
   match ip address prefix-list 2001:db8::1-pl-ipv6
@@ -14,13 +15,17 @@ route-map 2001:db8::1-out permit 2
   match ipv6 address prefix-list 2001:db8::1-pl-ipv6
 
 
-ip prefix-list 2001:db8::1-pl-ipv6 deny any
+
+ip prefix-list 2001:db8::1-pl-ipv6 seq 2 deny any
 
 
 
-ip prefix-list 2001:db8::1-inpl-ipv6 deny any
 
-ipv6 prefix-list 2001:db8::1-inpl-ipv6 deny any
+
+
+ip prefix-list 2001:db8::1-inpl-ipv6 seq 1 deny any
+
+ipv6 prefix-list 2001:db8::1-inpl-ipv6 seq 2 deny any
 route-map 2001:db8::1-in permit 3
   match ip address prefix-list 2001:db8::1-inpl-ipv6
 route-map 2001:db8::1-in permit 4

--- a/internal/frr/testdata/TestTwoRoutersTwoNeighbors.golden
+++ b/internal/frr/testdata/TestTwoRoutersTwoNeighbors.golden
@@ -5,30 +5,36 @@ ip nht resolve-via-default
 ipv6 nht resolve-via-default
 
 
-ip prefix-list 192.168.1.2-100-ipv4-localpref-prefixes permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-100-ipv4-localpref-prefixes seq 1 permit 192.169.1.0/24
 route-map 192.168.1.2-out permit 1
   match ip address prefix-list 192.168.1.2-100-ipv4-localpref-prefixes
   set local-preference 100
   on-match next
-ip prefix-list 192.168.1.2-10:169-ipv4-community-prefixes permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-10:169-ipv4-community-prefixes seq 1 permit 192.169.1.0/24
 route-map 192.168.1.2-out permit 2
   match ip address prefix-list 192.168.1.2-10:169-ipv4-community-prefixes
   set community 10:169 additive
   on-match next
-ip prefix-list 192.168.1.2-10:170-ipv4-community-prefixes permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.2-10:170-ipv4-community-prefixes seq 1 permit 192.169.1.0/24
 route-map 192.168.1.2-out permit 3
   match ip address prefix-list 192.168.1.2-10:170-ipv4-community-prefixes
   set community 10:170 additive
   on-match next
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.169.1.0/24
 
-ip prefix-list 192.168.1.2-150-ipv4-localpref-prefixes permit 192.169.1.0/22
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
+
+
+ip prefix-list 192.168.1.2-150-ipv4-localpref-prefixes seq 1 permit 192.169.1.0/22
 route-map 192.168.1.2-out permit 4
   match ip address prefix-list 192.168.1.2-150-ipv4-localpref-prefixes
   set local-preference 150
   on-match next
-ip prefix-list 192.168.1.2-10:170-ipv4-community-prefixes permit 192.169.1.0/22
+
+ip prefix-list 192.168.1.2-10:170-ipv4-community-prefixes seq 2 permit 192.169.1.0/22
 route-map 192.168.1.2-out permit 5
   match ip address prefix-list 192.168.1.2-10:170-ipv4-community-prefixes
   set community 10:170 additive
@@ -39,15 +45,18 @@ route-map 192.168.1.2-out permit 6
   set large-community 123:456:7890 additive
   on-match next
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.169.1.0/22
 
-ip prefix-list 192.168.1.2-10:170-ipv4-community-prefixes permit 192.170.1.0/22
+ip prefix-list 192.168.1.2-pl-ipv4 seq 2 permit 192.169.1.0/22
+
+
+ip prefix-list 192.168.1.2-10:170-ipv4-community-prefixes seq 3 permit 192.170.1.0/22
 route-map 192.168.1.2-out permit 7
   match ip address prefix-list 192.168.1.2-10:170-ipv4-community-prefixes
   set community 10:170 additive
   on-match next
 
-ip prefix-list 192.168.1.2-pl-ipv4 permit 192.170.1.0/22
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 3 permit 192.170.1.0/22
 
 route-map 192.168.1.2-out permit 8
   match ip address prefix-list 192.168.1.2-pl-ipv4
@@ -55,13 +64,17 @@ route-map 192.168.1.2-out permit 9
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 4 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 10
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 11
@@ -69,7 +82,8 @@ route-map 192.168.1.2-in permit 11
 
 
 
-ip prefix-list 192.168.1.3-pl-ipv4 permit 192.169.1.0/24
+
+ip prefix-list 192.168.1.3-pl-ipv4 seq 1 permit 192.169.1.0/24
 
 route-map 192.168.1.3-out permit 1
   match ip address prefix-list 192.168.1.3-pl-ipv4
@@ -77,13 +91,17 @@ route-map 192.168.1.3-out permit 2
   match ipv6 address prefix-list 192.168.1.3-pl-ipv4
 
 
-ipv6 prefix-list 192.168.1.3-pl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.3-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.168.1.3-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.3-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.3-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.3-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.3-in permit 3
   match ip address prefix-list 192.168.1.3-inpl-ipv4
 route-map 192.168.1.3-in permit 4

--- a/internal/frr/testdata/TestTwoRoutersTwoNeighborsBFD.golden
+++ b/internal/frr/testdata/TestTwoRoutersTwoNeighborsBFD.golden
@@ -11,14 +11,18 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4
@@ -31,14 +35,18 @@ route-map 192.168.1.3-out permit 2
   match ipv6 address prefix-list 192.168.1.3-pl-ipv4
 
 
-ip prefix-list 192.168.1.3-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.3-pl-ipv4 deny any
+
+ip prefix-list 192.168.1.3-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.3-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.168.1.3-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.3-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.3-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.3-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.3-in permit 3
   match ip address prefix-list 192.168.1.3-inpl-ipv4
 route-map 192.168.1.3-in permit 4

--- a/internal/frr/testdata/TestTwoSessionsAcceptAll.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptAll.golden
@@ -11,14 +11,18 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.168.1.2-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
 
 
@@ -29,14 +33,18 @@ route-map 192.168.1.3-out permit 2
   match ipv6 address prefix-list 192.168.1.3-pl-ipv4
 
 
-ip prefix-list 192.168.1.3-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.3-pl-ipv4 deny any
+
+ip prefix-list 192.168.1.3-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.3-pl-ipv4 seq 2 deny any
 
 
 
-ip prefix-list 192.168.1.3-inpl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.3-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.3-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.3-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.3-in permit 3
 
 

--- a/internal/frr/testdata/TestTwoSessionsAcceptSomeV4.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptSomeV4.golden
@@ -11,14 +11,18 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
 
-ip prefix-list 192.168.1.2-inpl-ipv4 permit 192.168.1.0/24
-
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 2 deny any
 
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 permit 192.168.1.0/24
+
+
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4
@@ -31,15 +35,19 @@ route-map 192.168.1.3-out permit 2
   match ipv6 address prefix-list 192.168.1.3-pl-ipv4
 
 
-ip prefix-list 192.168.1.3-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.3-pl-ipv4 deny any
 
-ip prefix-list 192.168.1.3-inpl-ipv4 permit 192.170.1.0/24
-ip prefix-list 192.168.1.3-inpl-ipv4 permit 192.169.1.0/24
+ip prefix-list 192.168.1.3-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.3-pl-ipv4 seq 2 deny any
 
 
 
-ipv6 prefix-list 192.168.1.3-inpl-ipv4 deny any
+
+ip prefix-list 192.168.1.3-inpl-ipv4 seq 1 permit 192.170.1.0/24
+ip prefix-list 192.168.1.3-inpl-ipv4 seq 2 permit 192.169.1.0/24
+
+
+
+ipv6 prefix-list 192.168.1.3-inpl-ipv4 seq 3 deny any
 route-map 192.168.1.3-in permit 3
   match ip address prefix-list 192.168.1.3-inpl-ipv4
 route-map 192.168.1.3-in permit 4

--- a/internal/frr/testdata/TestTwoSessionsAcceptV4AndV6.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptV4AndV6.golden
@@ -11,15 +11,19 @@ route-map 192.168.1.2-out permit 2
   match ipv6 address prefix-list 192.168.1.2-pl-ipv4
 
 
-ip prefix-list 192.168.1.2-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.2-pl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 permit fc00:f853:ccd:e800::/64
-ip prefix-list 192.168.1.2-inpl-ipv4 permit 192.168.1.0/24
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 2 deny any
 
 
 
-ipv6 prefix-list 192.168.1.2-inpl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 1 permit fc00:f853:ccd:e800::/64
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 2 permit 192.168.1.0/24
+
+
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 3 deny any
 route-map 192.168.1.2-in permit 3
   match ip address prefix-list 192.168.1.2-inpl-ipv4
 route-map 192.168.1.2-in permit 4
@@ -32,15 +36,19 @@ route-map 192.168.1.3-out permit 2
   match ipv6 address prefix-list 192.168.1.3-pl-ipv4
 
 
-ip prefix-list 192.168.1.3-pl-ipv4 deny any
-ipv6 prefix-list 192.168.1.3-pl-ipv4 deny any
 
-ipv6 prefix-list 192.168.1.3-inpl-ipv4 permit fc00:f853:ccd:e799::/64
-ip prefix-list 192.168.1.3-inpl-ipv4 permit 192.169.1.0/24
+ip prefix-list 192.168.1.3-pl-ipv4 seq 1 deny any
+ipv6 prefix-list 192.168.1.3-pl-ipv4 seq 2 deny any
 
 
 
-ipv6 prefix-list 192.168.1.3-inpl-ipv4 deny any
+
+ipv6 prefix-list 192.168.1.3-inpl-ipv4 seq 1 permit fc00:f853:ccd:e799::/64
+ip prefix-list 192.168.1.3-inpl-ipv4 seq 2 permit 192.169.1.0/24
+
+
+
+ipv6 prefix-list 192.168.1.3-inpl-ipv4 seq 3 deny any
 route-map 192.168.1.3-in permit 3
   match ip address prefix-list 192.168.1.3-inpl-ipv4
 route-map 192.168.1.3-in permit 4


### PR DESCRIPTION
Aligning to the latest changes in MetalLB, we force the sequence numbers of the prefix lists from outside to ease the job of the reloader.