### PR TITLE
API: add a LastConversionResult field to the node state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=daemon-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	cp config/crd/bases/*.yaml charts/frr-k8s/charts/crds/templates
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/api/v1beta1/frr_node_state_types.go
+++ b/api/v1beta1/frr_node_state_types.go
@@ -26,9 +26,10 @@ type FRRNodeStateSpec struct {
 
 // FRRNodeStateStatus defines the observed state of FRRNodeState.
 type FRRNodeStateStatus struct {
-	DesiredConfig    string `json:"desiredConfig,omitempty"`
-	RunningConfig    string `json:"runningConfig,omitempty"`
-	LastReloadResult string `json:"lastReloadResult,omitempty"`
+	DesiredConfig        string `json:"desiredConfig,omitempty"`
+	RunningConfig        string `json:"runningConfig,omitempty"`
+	LastConversionResult string `json:"lastConversionResult,omitempty"`
+	LastReloadResult     string `json:"lastReloadResult,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrnodestates.yaml
+++ b/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrnodestates.yaml
@@ -40,6 +40,8 @@ spec:
             properties:
               desiredConfig:
                 type: string
+              lastConversionResult:
+                type: string
               lastReloadResult:
                 type: string
               runningConfig:

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -418,6 +418,8 @@ spec:
             properties:
               desiredConfig:
                 type: string
+              lastConversionResult:
+                type: string
               lastReloadResult:
                 type: string
               runningConfig:

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -418,6 +418,8 @@ spec:
             properties:
               desiredConfig:
                 type: string
+              lastConversionResult:
+                type: string
               lastReloadResult:
                 type: string
               runningConfig:

--- a/config/crd/bases/frrk8s.metallb.io_frrnodestates.yaml
+++ b/config/crd/bases/frrk8s.metallb.io_frrnodestates.yaml
@@ -40,6 +40,8 @@ spec:
             properties:
               desiredConfig:
                 type: string
+              lastConversionResult:
+                type: string
               lastReloadResult:
                 type: string
               runningConfig:

--- a/internal/controller/common_test.go
+++ b/internal/controller/common_test.go
@@ -72,23 +72,25 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&FRRConfigurationReconciler{
-		Client:     k8sManager.GetClient(),
-		Scheme:     k8sManager.GetScheme(),
-		FRRHandler: &fakeFRRConfigHandler,
-		Logger:     log.NewNopLogger(),
-		NodeName:   testNodeName,
-		Namespace:  testNamespace,
+		Client:       k8sManager.GetClient(),
+		Scheme:       k8sManager.GetScheme(),
+		FRRHandler:   &fakeFRRConfigHandler,
+		Logger:       log.NewNopLogger(),
+		NodeName:     testNodeName,
+		Namespace:    testNamespace,
+		ReloadStatus: fakeReloadStatus,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
 	updateChan = make(chan event.GenericEvent)
 	err = (&FRRStateReconciler{
-		Client:    k8sManager.GetClient(),
-		Scheme:    k8sManager.GetScheme(),
-		FRRStatus: fakeStatus,
-		Logger:    log.NewNopLogger(),
-		NodeName:  testNodeName,
-		Update:    updateChan,
+		Client:           k8sManager.GetClient(),
+		Scheme:           k8sManager.GetScheme(),
+		FRRStatus:        fakeStatus,
+		Logger:           log.NewNopLogger(),
+		NodeName:         testNodeName,
+		ConversionResult: fakeConversionRes,
+		Update:           updateChan,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/internal/controller/frrstate_controller_test.go
+++ b/internal/controller/frrstate_controller_test.go
@@ -34,8 +34,9 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	fakeStatus = &fakeFRRStatus{}
-	updateChan chan event.GenericEvent
+	fakeStatus        = &fakeFRRStatus{}
+	updateChan        chan event.GenericEvent
+	fakeConversionRes = &fakeConversionResult{}
 )
 
 type fakeFRRStatus struct {
@@ -52,10 +53,18 @@ func (f *fakeFRRStatus) GetStatus() frr.Status {
 	}
 }
 
+type fakeConversionResult struct {
+	result string
+}
+
+func (f *fakeConversionResult) ConversionResult() string {
+	return f.result
+}
+
 var _ = Describe("Frrk8s node status", func() {
 	Context("when a FRRConfiguration is created", func() {
 
-		It("should report the status when notified by FRR", func() {
+		It("should report the status when notified", func() {
 			fakeStatus.lastApplied = "foo"
 			fakeStatus.lastDesired = "bar"
 			fakeStatus.lastReloadResult = "baz"
@@ -119,6 +128,31 @@ var _ = Describe("Frrk8s node status", func() {
 						"LastReloadResult": Equal("error"),
 					}),
 				}))
+
+			fakeConversionRes.result = "aaaa"
+			updateChan <- NewStateEvent()
+
+			Eventually(func() frrk8sv1beta1.FRRNodeState {
+				nodeStatusList := frrk8sv1beta1.FRRNodeStateList{}
+				err := k8sClient.List(context.Background(), &nodeStatusList)
+				Expect(err).ToNot(HaveOccurred())
+				if len(nodeStatusList.Items) != 1 {
+					return frrk8sv1beta1.FRRNodeState{}
+				}
+				return nodeStatusList.Items[0]
+			}, time.Minute, 5*time.Second).Should(
+				gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"ObjectMeta": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"Name": Equal(testNodeName),
+					}),
+					"Status": gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"RunningConfig":        Equal("foo"),
+						"DesiredConfig":        Equal("bar1"),
+						"LastReloadResult":     Equal("error"),
+						"LastConversionResult": Equal("aaaa"),
+					}),
+				}))
+
 		})
 
 		It("should obfuscate the passwords", func() {


### PR DESCRIPTION
This might be useful to understand why the conversion failed without having to look at the logs. The FRR status is useful, but sometimes the configuration is blocked earlier (for example when the password is missing from secrets).

Based off https://github.com/metallb/frr-k8s/pull/52