### PR TITLE
Charts: disable service monitors by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ deploy-helm: helm deploy-cluster deploy-prometheus
 	$(KUBECTL) create ns ${NAMESPACE} || true
 	$(KUBECTL) label ns ${NAMESPACE} pod-security.kubernetes.io/enforce=privileged
 	$(HELM) install frrk8s charts/frr-k8s/ --set frrk8s.image.tag=${IMG_TAG} --set frrk8s.logLevel=debug --set prometheus.rbacPrometheus=true \
-	--set prometheus.serviceAccount=prometheus-k8s --set prometheus.namespace=monitoring --namespace ${NAMESPACE}
+	--set prometheus.serviceAccount=prometheus-k8s --set prometheus.namespace=monitoring --set prometheus.serviceMonitor.enabled=true --namespace ${NAMESPACE}
 	sleep 2s # wait for daemonset to be created
 	$(KUBECTL) -n frr-k8s-system wait --for=condition=Ready --all pods --timeout 300s
 

--- a/charts/frr-k8s/README.md
+++ b/charts/frr-k8s/README.md
@@ -81,7 +81,7 @@ Kubernetes: `>= 1.19.0-0`
 | prometheus.serviceAccount | string | `""` |  |
 | prometheus.serviceMonitor.additionalLabels | object | `{}` |  |
 | prometheus.serviceMonitor.annotations | object | `{}` |  |
-| prometheus.serviceMonitor.enabled | bool | `true` |  |
+| prometheus.serviceMonitor.enabled | bool | `false` |  |
 | prometheus.serviceMonitor.interval | string | `nil` |  |
 | prometheus.serviceMonitor.jobLabel | string | `"app.kubernetes.io/name"` |  |
 | prometheus.serviceMonitor.metricRelabelings | list | `[]` |  |

--- a/charts/frr-k8s/values.yaml
+++ b/charts/frr-k8s/values.yaml
@@ -55,7 +55,7 @@ prometheus:
   # Prometheus Operator ServiceMonitors.
   serviceMonitor:
     # enable support for Prometheus Operator
-    enabled: true
+    enabled: false
 
     additionalLabels: {}
     # optional additional annotations for the controller serviceMonitor
@@ -85,35 +85,6 @@ prometheus:
     #   target_label: nodename
     #   replacement: $1
     #   action: replace
-
-#  # Prometheus Operator alertmanager alerts
-#  prometheusRule:
-#    # enable alertmanager alerts
-#    enabled: false
-#
-#    # optional additionnal labels for prometheusRules
-#    additionalLabels: {}
-#
-#    # optional annotations for prometheusRules
-#    annotations: {}
-#
-#
-#    addressPoolUsage:
-#      enabled: true
-#      thresholds:
-#        - percent: 75
-#          labels:
-#            severity: warning
-#        - percent: 85
-#          labels:
-#            severity: warning
-#        - percent: 95
-#          labels:
-#            severity: alert
-#
-#
-#    extraAlerts: []
-
 
 # controller contains configuration specific to the FRRK8s controller
 # daemonset.


### PR DESCRIPTION
We don't know if the dest cluster has the prometheus operator deployed, so it's not safe to assume so by default.

Also, removing comments related to metallb alarms.