### PR TITLE
dump: hide cleartext passwords

### DIFF
--- a/internal/controller/dump.go
+++ b/internal/controller/dump.go
@@ -13,7 +13,7 @@ import (
 func dumpK8sConfigs(c frrk8sv1beta1.FRRConfigurationList) string {
 	res := ""
 	for _, cfg := range c.Items {
-		res = res + "\n" + dumpResource(cfg)
+		res = res + "\n" + dumpResource(sanitizedConfig(cfg))
 	}
 	return res
 }
@@ -42,4 +42,16 @@ func dumpResource(i interface{}) string {
 		return spew.Sdump(i)
 	}
 	return string(toDump)
+}
+
+func sanitizedConfig(c frrk8sv1beta1.FRRConfiguration) frrk8sv1beta1.FRRConfiguration {
+	res := c.DeepCopy()
+	for _, router := range res.Spec.BGP.Routers {
+		for i := range router.Neighbors {
+			router.Neighbors[i].Password = "<retracted>"
+		}
+	}
+	delete(res.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+
+	return *res
 }


### PR DESCRIPTION
We forgot to hide cleartext passwords when we added them, we also remove the `kubectl.kubernetes.io/last-applied-configuration` annotation from the dumped config as it contains a password + redundant data.