### PR TITLE
helm: fix metricRelabelings

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 ### Chores
 
 - Enforce adding release notes in CI ([PR #79](https://github.com/metallb/frr-k8s/pull/79))
+- helm: Fix metricRelabelings templating ([PR #83](https://github.com/metallb/frr-k8s/pull/83))
 
 ## Release v0.0.3
 

--- a/charts/frr-k8s/templates/service-monitor.yaml
+++ b/charts/frr-k8s/templates/service-monitor.yaml
@@ -37,9 +37,17 @@ spec:
 {{ toYaml .Values.prometheus.serviceMonitor.tlsConfig | indent 8 }}      
 {{- end }}
 {{ end }}
+{{ if .Values.frrk8s.frr.secureMetricsPort }}
     - port: "frrmetricshttps"
       honorLabels: true
-{{ if .Values.frrk8s.frr.secureMetricsPort }}
+      {{- if .Values.prometheus.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{- toYaml .Values.prometheus.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end -}}
+      {{- if .Values.prometheus.serviceMonitor.relabelings }}
+      relabelings:
+      {{- toYaml .Values.prometheus.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
       {{- if .Values.prometheus.serviceMonitor.interval }}
       interval: {{ .Values.prometheus.serviceMonitor.interval }}
       {{- end }}


### PR DESCRIPTION
We missed templating the variable for frr's metrics port. Also moved the port conditional to where it belongs.
Fixing this will allow us to fetch the metrics as metallb's, making the integration easier:
```yaml
metricRelabelings:
    - sourceLabels: [__name__]
      regex: "frrk8s_bgp_(.*)"
      targetLabel: "__name__"
      replacement: "metallb_bgp_$1"
    - sourceLabels: [__name__]
      regex: "frrk8s_bfd_(.*)"
      targetLabel: "__name__"
      replacement: "metallb_bfd_$1"
```