### PR TITLE
controller: fix merging neighbor's timers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ## Next release
 
+### Bug fixes
+
+- Merging neighbors always failed when holdtime and keepalivetime were set ([PR #86](https://github.com/metallb/frr-k8s/pull/86)).
+
 ### Chores
 
 - Enforce adding release notes in CI ([PR #79](https://github.com/metallb/frr-k8s/pull/79))

--- a/internal/controller/merge.go
+++ b/internal/controller/merge.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/metallb/frr-k8s/internal/frr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -221,11 +222,11 @@ func neighborsAreCompatible(n1, n2 *frr.NeighborConfig) error {
 		return fmt.Errorf("conflicting ebgp-multihop specified for %s", neighborKey)
 	}
 
-	if n1.HoldTime != n2.HoldTime {
+	if !ptrsEqual(n1.HoldTime, n2.HoldTime, uint64(180*time.Second)) {
 		return fmt.Errorf("multiple hold times specified for %s", neighborKey)
 	}
 
-	if n1.KeepaliveTime != n2.KeepaliveTime {
+	if !ptrsEqual(n1.KeepaliveTime, n2.KeepaliveTime, uint64(60*time.Second)) {
 		return fmt.Errorf("multiple keepalive times specified for %s", neighborKey)
 	}
 


### PR DESCRIPTION
We accidentally compared pointers instead of their values.