### PR TITLE
Rel notes: merge with union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+RELEASE_NOTES.md merge=union


### PR DESCRIPTION
The rel notes are appended, so it makes sense to do union instead of merging, otherwise each PR will cause a conflict.