### PR TITLE
webhook: validate resources from all namespaces

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,10 @@
 
 - Support a --always-block parameter. The parameter accepts a list of comma separated cidrs to always block. This is useful to protect well known cidrs such as pods or clusterIPs. ([PR 88](https://github.com/metallb/frr-k8s/pull/88))
 
+### Bug fixes
+
+- FRRConfigurations from namespaces different than the one the daemon is deployed on were not validated with other resoureces. ([PR 91](https://github.com/metallb/frr-k8s/pull/91))
+
 ## Release v0.0.4
 
 ### Bug fixes

--- a/api/v1beta1/frrconfiguration_webhook.go
+++ b/api/v1beta1/frrconfiguration_webhook.go
@@ -22,7 +22,6 @@ var (
 	Logger        log.Logger
 	WebhookClient client.Reader
 	Validate      func(resources ...client.ObjectList) error
-	Namespace     string
 )
 
 func (frrConfig *FRRConfiguration) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -124,7 +123,7 @@ func validateConfig(frrConfig *FRRConfiguration) error {
 
 var getFRRConfigurations = func() (*FRRConfigurationList, error) {
 	frrConfigurationsList := &FRRConfigurationList{}
-	err := WebhookClient.List(context.Background(), frrConfigurationsList, &client.ListOptions{Namespace: Namespace})
+	err := WebhookClient.List(context.Background(), frrConfigurationsList)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to get existing FRRConfiguration objects")
 	}

--- a/api/v1beta1/frrconfiguration_webhook_test.go
+++ b/api/v1beta1/frrconfiguration_webhook_test.go
@@ -14,7 +14,6 @@ import (
 const TestNamespace = "test-namespace"
 
 func TestValidateFRRConfiguration(t *testing.T) {
-	Namespace = TestNamespace
 	Logger = log.NewNopLogger()
 	existingConfig := FRRConfiguration{
 		ObjectMeta: metav1.ObjectMeta{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -163,7 +163,7 @@ func main() {
 
 		if enableWebhook {
 			setupLog.Info("Starting webhooks")
-			err := setupWebhook(mgr, namespace, logger)
+			err := setupWebhook(mgr, logger)
 			if err != nil {
 				setupLog.Error(err, "unable to create", "webhooks")
 				os.Exit(1)
@@ -259,10 +259,9 @@ func setupCertRotation(notifyFinished chan struct{}, mgr manager.Manager, logger
 	return nil
 }
 
-func setupWebhook(mgr manager.Manager, namespace string, logger log.Logger) error {
+func setupWebhook(mgr manager.Manager, logger log.Logger) error {
 	level.Info(logger).Log("op", "startup", "action", "webhooks enabled")
 
-	frrk8sv1beta1.Namespace = namespace
 	frrk8sv1beta1.Logger = logger
 	frrk8sv1beta1.WebhookClient = mgr.GetAPIReader()
 	frrk8sv1beta1.Validate = controller.Validate

--- a/e2etests/tests/webhooks.go
+++ b/e2etests/tests/webhooks.go
@@ -200,6 +200,32 @@ var _ = ginkgo.Describe("Webhooks", func() {
 			err = updater.Update([]corev1.Secret{}, cfg2)
 			framework.ExpectError(err)
 			Expect(err.Error()).To(ContainSubstring("different asns"))
+
+			ginkgo.By("Attempting to create a third config in a different namespace on the first node with a different ASN")
+			cfg3 := frrk8sv1beta1.FRRConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "webhook-cfg3",
+					Namespace: "default",
+				},
+				Spec: frrk8sv1beta1.FRRConfigurationSpec{
+					BGP: frrk8sv1beta1.BGPConfig{
+						Routers: []frrk8sv1beta1.Router{
+							{
+								ASN: 200,
+								VRF: "",
+							},
+						},
+					},
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/hostname": nodes[0].GetLabels()["kubernetes.io/hostname"],
+						},
+					},
+				},
+			}
+			err = updater.Update([]corev1.Secret{}, cfg3)
+			framework.ExpectError(err)
+			Expect(err.Error()).To(ContainSubstring("different asns"))
 		})
 
 		ginkgo.It("Should not reject a resource with a missing secret ref", func() {


### PR DESCRIPTION
We accidently validated only against resources from the namespace the daemon is deployed on. This fixes it and modifies the relevant e2e.