### PR TITLE
helm: add an option to disable the webhook's cert rotation

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,10 @@
 
 - FRRConfigurations from namespaces different than the one the daemon is deployed on were not validated with other resoureces. ([PR 91](https://github.com/metallb/frr-k8s/pull/91))
 
+### Chores
+
+- helm: add an option to disable the webhook's cert rotation. ([PR 93](https://github.com/metallb/frr-k8s/pull/93))
+
 ## Release v0.0.4
 
 ### Bug fixes

--- a/charts/frr-k8s/README.md
+++ b/charts/frr-k8s/README.md
@@ -26,6 +26,7 @@ Kubernetes: `>= 1.19.0-0`
 | crds.validationFailurePolicy | string | `"Fail"` |  |
 | frrk8s.affinity | object | `{}` |  |
 | frrk8s.alwaysBlock | string | `""` |  |
+| frrk8s.disableCertRotation | bool | `false` |  |
 | frrk8s.frr.image.pullPolicy | string | `nil` |  |
 | frrk8s.frr.image.repository | string | `"quay.io/frrouting/frr"` |  |
 | frrk8s.frr.image.tag | string | `"8.4.2"` |  |

--- a/charts/frr-k8s/templates/webhooks.yaml
+++ b/charts/frr-k8s/templates/webhooks.yaml
@@ -34,6 +34,9 @@ spec:
         - --log-level={{ . }}
         {{- end }}
         - "--webhook-mode=onlywebhook"
+        {{- if .Values.frrk8s.disableCertRotation }}
+        - "--disable-cert-rotation=true"
+        {{- end }}
         - "--namespace=$(NAMESPACE)"
         - --health-probe-bind-address={{.Values.prometheus.metricsBindAddress}}:{{ .Values.frrk8s.healthPort }}
         env:

--- a/charts/frr-k8s/values.yaml
+++ b/charts/frr-k8s/values.yaml
@@ -149,6 +149,8 @@ frrk8s:
     periodSeconds: 5
   ## A comma separated list of cidrs we want always to block for incoming routes
   alwaysBlock: ""
+  ## Specifies whether the cert rotator works as part of the webhook.
+  disableCertRotation: false
   # frr contains configuration specific to the FRR container,
   frr:
     image:


### PR DESCRIPTION
We add an option to disable the webhook's cert rotator, this enables another entity to generate and manage the relevant secret.