### PR TITLE
Fix parsing empty always-block flag

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
 
 - FRRConfigurations from namespaces different than the one the daemon is deployed on were not validated with other resoureces. ([PR 91](https://github.com/metallb/frr-k8s/pull/91))
 
+- Empty always-block flag was not parsed correctly. ([PR 95](https://github.com/metallb/frr-k8s/pull/95))
+
 ### Chores
 
 - helm: add an option to disable the webhook's cert rotation. ([PR 93](https://github.com/metallb/frr-k8s/pull/93))

--- a/cmd/cidrs_test.go
+++ b/cmd/cidrs_test.go
@@ -17,6 +17,11 @@ func TestParseCIDRS(t *testing.T) {
 		mustFail bool
 	}{
 		{
+			name:     "empty",
+			cidrs:    "",
+			expected: nil,
+		},
+		{
 			name:     "simple",
 			cidrs:    "192.168.1.2/24,fc00:f853:ccd:e800::/64",
 			expected: []net.IPNet{*ipv4CIDR, *ipv6CIDR},

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -275,10 +275,11 @@ func setupWebhook(mgr manager.Manager, logger log.Logger) error {
 }
 
 func parseCIDRs(cidrs string) ([]net.IPNet, error) {
-	elems := strings.Split(cidrs, ",")
-	if len(elems) == 0 {
+	if cidrs == "" {
 		return nil, nil
 	}
+
+	elems := strings.Split(cidrs, ",")
 	res := make([]net.IPNet, 0, len(elems))
 	for _, e := range elems {
 		trimmed := strings.Trim(e, " ")


### PR DESCRIPTION
Fixes parsing empty always-block flag as no cidrs specified, the current way is flawed because:
```go
	elems := strings.Split("", ",")
	fmt.Println(elems, ",", len(elems))
```
returns:
```go
[] , 1
```