### PR TITLE
helm: align webhooks probes with kustomize

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,8 @@
 
 - Empty always-block flag was not parsed correctly. ([PR 95](https://github.com/metallb/frr-k8s/pull/95))
 
+- helm: webhooks probes pointed to the wrong endpoints. ([PR 97](https://github.com/metallb/frr-k8s/pull/97))
+
 ### Chores
 
 - helm: add an option to disable the webhook's cert rotation. ([PR 93](https://github.com/metallb/frr-k8s/pull/93))

--- a/charts/frr-k8s/templates/webhooks.yaml
+++ b/charts/frr-k8s/templates/webhooks.yaml
@@ -38,7 +38,7 @@ spec:
         - "--disable-cert-rotation=true"
         {{- end }}
         - "--namespace=$(NAMESPACE)"
-        - --health-probe-bind-address={{.Values.prometheus.metricsBindAddress}}:{{ .Values.frrk8s.healthPort }}
+        - --health-probe-bind-address=:8081
         env:
         - name: NAMESPACE
           valueFrom:
@@ -58,20 +58,20 @@ spec:
         {{- if .Values.frrk8s.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /livez
-            port: {{ .Values.frrk8s.frr.metricsPort }}
-            host: {{ .Values.frrk8s.frr.metricsBindAddress }}
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: {{ .Values.frrk8s.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frrk8s.livenessProbe.periodSeconds }}
           failureThreshold: {{ .Values.frrk8s.livenessProbe.failureThreshold }}
         {{- end }}
-        {{- if .Values.frrk8s.startupProbe.enabled }}
-        startupProbe:
+        {{- if .Values.frrk8s.readinessProbe.enabled }}
+        readinessProbe:
           httpGet:
-            path: /livez
-            port: {{ .Values.frrk8s.frr.metricsPort }}
-            host: {{ .Values.frrk8s.frr.metricsBindAddress }}
-          failureThreshold: {{ .Values.frrk8s.startupProbe.failureThreshold }}
-          periodSeconds: {{ .Values.frrk8s.startupProbe.periodSeconds }}
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: {{ .Values.frrk8s.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.frrk8s.readinessProbe.periodSeconds }}
+          failureThreshold: {{ .Values.frrk8s.readinessProbe.failureThreshold }}
         {{- end }}
         {{- with .Values.frrk8s.resources }}
         resources:


### PR DESCRIPTION
The liveness/readiness probes of the webhook pod pointed to the wrong endpoints,
essentially checking the endpoint of the daemon pod (via 127.0.0.1).
This fixes this by aligning with what we do in kustomize, probing the
pod's correct livez/healthz endpoints.