### PR TITLE
Add option to enable the rotator RestartOnSecretRefresh

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Support a --always-block parameter. The parameter accepts a list of comma separated cidrs to always block. This is useful to protect well known cidrs such as pods or clusterIPs. ([PR 88](https://github.com/metallb/frr-k8s/pull/88))
+- Support restarting the webhook pod when the rotator updates its cert secret.([PR 100](https://github.com/metallb/frr-k8s/pull/100)) 
 
 ### Bug fixes
 

--- a/charts/frr-k8s/README.md
+++ b/charts/frr-k8s/README.md
@@ -58,6 +58,7 @@ Kubernetes: `>= 1.19.0-0`
 | frrk8s.readinessProbe.timeoutSeconds | int | `1` |  |
 | frrk8s.reloader.resources | object | `{}` |  |
 | frrk8s.resources | object | `{}` |  |
+| frrk8s.restartOnRotatorSecretRefresh | bool | `false` |  |
 | frrk8s.runtimeClassName | string | `""` |  |
 | frrk8s.serviceAccount.annotations | object | `{}` |  |
 | frrk8s.serviceAccount.create | bool | `true` |  |

--- a/charts/frr-k8s/templates/webhooks.yaml
+++ b/charts/frr-k8s/templates/webhooks.yaml
@@ -37,6 +37,9 @@ spec:
         {{- if .Values.frrk8s.disableCertRotation }}
         - "--disable-cert-rotation=true"
         {{- end }}
+        {{- if .Values.frrk8s.restartOnRotatorSecretRefresh }}
+        - "--restart-on-rotator-secret-refresh=true"
+        {{- end }}
         - "--namespace=$(NAMESPACE)"
         - --health-probe-bind-address=:8081
         env:

--- a/charts/frr-k8s/values.yaml
+++ b/charts/frr-k8s/values.yaml
@@ -151,6 +151,9 @@ frrk8s:
   alwaysBlock: ""
   ## Specifies whether the cert rotator works as part of the webhook.
   disableCertRotation: false
+  ## Specifies whether the pod restarts when the rotator refreshes the cert secret.
+  ## Enabling this proved useful for the webhook's stability when it is redeployed multiple times in succession.
+  restartOnRotatorSecretRefresh: false
   # frr contains configuration specific to the FRR container,
   frr:
     image:


### PR DESCRIPTION
When the webhook pod is redeployed multiple times in succession sometimes the requests for the webhook hang on `tls: failed to verify certificate` and it is not solved until the pod is restarted manually. While the reason the flag solves the issue is not totally clear, introducing the flag for the operator to consume is reasonable.