### PR TITLE
CI: don't check generated files for dependabot prs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,33 @@ jobs:
         with:
           skip-upload: true
 
+  check-generated:
+    runs-on: ubuntu-22.04
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check Generated
+        run: |
+          make bumplicense
+          go mod tidy
+          pushd e2etests
+          go mod tidy
+          popd
+          make manifests
+          make generate-all-in-one
+          make api-docs
+          make checkuncommitted
+
+      - name: Helm doc generate
+        uses: docker://jnorwood/helm-docs:v1.10.0
+
+      - name: Check if  docs are different
+        run: make checkuncommitted
+
   check-changelog:
     runs-on: ubuntu-22.04
     if: github.actor != 'dependabot[bot]'
@@ -86,21 +113,6 @@ jobs:
       - name: Lint
         run: |
           ENV=host make lint
-          make bumplicense
-          go mod tidy
-          pushd e2etests
-          go mod tidy
-          popd
-          make manifests
-          make generate-all-in-one
-          make api-docs
-          make checkuncommitted
-
-      - name: Helm doc generate
-        uses: docker://jnorwood/helm-docs:v1.10.0
-
-      - name: Check if  docs are different
-        run: make checkuncommitted
 
   build-test-images:
     runs-on: ubuntu-22.04

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@
 - helm: add an option to disable the webhook's cert rotation. ([PR 93](https://github.com/metallb/frr-k8s/pull/93))
 - add a new logo!
 - CI: add a MetalLB E2E lane. ([PR 99](https://github.com/metallb/frr-k8s/pull/99))
+- CI: don't run auto-generated files checks on dependabot PRs ([PR 111](https://github.com/metallb/frr-k8s/pull/111))
 
 ## Release v0.0.4
 


### PR DESCRIPTION
Assuming dependabot knows how to update a dependency, we don't want to check changes in go.mod (but also, all the generated files checks we do) on dependabot PRs.

So, we split the lint lane in a "lint" job which performs only linting, and a more generic "check generated" that does not run when dependabot files a PR.