### PR TITLE
Makefile: ignore kubectl errors when checking the version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: kubectl
 kubectl: $(KUBECTL) ## Download kubectl locally if necessary. If wrong version is installed, it will be overwritten.
 $(KUBECTL): $(LOCALBIN)
-	test -s $(LOCALBIN)/kubectl && $(LOCALBIN)/kubectl version | grep -q $(KUBECTL_VERSION) || \
+	test -s $(LOCALBIN)/kubectl && $(LOCALBIN)/kubectl -client version | grep -q $(KUBECTL_VERSION) || \
 	curl -o $(LOCALBIN)/kubectl -LO https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$$(go env GOOS)/$$(go env GOARCH)/kubectl
 	chmod +x $(LOCALBIN)/kubectl
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@
 - add a new logo!
 - CI: add a MetalLB E2E lane. ([PR 99](https://github.com/metallb/frr-k8s/pull/99))
 - CI: don't run auto-generated files checks on dependabot PRs ([PR 111](https://github.com/metallb/frr-k8s/pull/111))
+- kubectl: don't download if cluster is not reacheable ([PR 112](https://github.com/metallb/frr-k8s/pull/112))
 
 ## Release v0.0.4
 


### PR DESCRIPTION
If there is no connectivity to the cluster, kubectl version fails and so the version check does not even get to check the version.

Here we redirect stderror so we can check the version and avoid downloading every time.