### PR TITLE
helm: add namespacing to all namespaced resources

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # FRRK8s Release Notes
 
+## Release v0.0.9
+
+### Bug fixes
+ - helm: namespace all namespaced resources ([PR 117](https://github.com/metallb/frr-k8s/pull/117))
+
 ## Release v0.0.8
 
 ### Features

--- a/charts/frr-k8s/templates/controller.yaml
+++ b/charts/frr-k8s/templates/controller.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "frrk8s.fullname" . }}-frr-startup
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "frrk8s.labels" . | nindent 4 }}
     app.kubernetes.io/component: frr-k8s
@@ -104,6 +105,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "frrk8s.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "frrk8s.labels" . | nindent 4 }}
     app.kubernetes.io/component: frr-k8s

--- a/charts/frr-k8s/templates/rbac.yaml
+++ b/charts/frr-k8s/templates/rbac.yaml
@@ -44,12 +44,13 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "frrk8s.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "frrk8s.fullname" . }}-controller
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "frrk8s.labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
@@ -60,7 +61,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "frrk8s.fullname" . }}-controller
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "frrk8s.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/frr-k8s/templates/service-accounts.yaml
+++ b/charts/frr-k8s/templates/service-accounts.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "frrk8s.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "frrk8s.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/frr-k8s/templates/webhooks.yaml
+++ b/charts/frr-k8s/templates/webhooks.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "frrk8s.fullname" . }}-webhook-server
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "frrk8s.labels" . | nindent 4 }}
     app.kubernetes.io/component: frr-k8s-webhook-server
@@ -117,11 +118,13 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: frr-k8s-webhook-server-cert
+  namespace: {{ .Release.Namespace | quote }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: frr-k8s-webhook-service
+  namespace: {{ .Release.Namespace | quote }}
 spec:
   ports:
   - port: 443


### PR DESCRIPTION
Some api-resources which are namespaced lack a namespace in this helm chart.
This works fine when using `helm install`, but I'm using a `ClusterResourceSet` (rollout via a `ConfigMap` when using `cluster-api`). When using this, resources without a namespace get silently dropped.
I've taken the liberty of adding namespaces wherever required. I've also added quoting everywhere to keep the style consistent.