### PR TITLE
Merge: don't convert the default values from seconds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ KUSTOMIZE_LAYER ?= default
 deploy-controller: kubectl kustomize ## Deploy controller to the K8s cluster specified in $KUBECONFIG.
 	cd config/frr-k8s && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUBECTL) -n ${NAMESPACE} delete ds frr-k8s-daemon || true
+	$(KUBECTL) -n ${NAMESPACE} delete deployment frr-k8s-webhook-server || true
 
 	$(KUSTOMIZE) build config/$(KUSTOMIZE_LAYER) | \
 		sed '/--log-level/a\        - --always-block=192.167.9.0/24,fc00:f553:ccd:e799::/64' |\
@@ -297,5 +298,4 @@ cutrelease: bumpversion generate-all-in-one helm-docs
 
 .PHONY: demoenv
 demoenv: deploy
-	cd hack/demo && ./demo.sh 
-
+	cd hack/demo && ./demo.sh

--- a/internal/controller/merge.go
+++ b/internal/controller/merge.go
@@ -4,10 +4,15 @@ package controller
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/metallb/frr-k8s/internal/frr"
 	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	defaultHoldTime      = 180
+	defaultKeepaliveTime = 60
+	defaultConnectTime   = 60
 )
 
 // Merges two router configs.
@@ -222,15 +227,15 @@ func neighborsAreCompatible(n1, n2 *frr.NeighborConfig) error {
 		return fmt.Errorf("conflicting ebgp-multihop specified for %s", neighborKey)
 	}
 
-	if !ptrsEqual(n1.HoldTime, n2.HoldTime, uint64(180*time.Second)) {
+	if !ptrsEqual(n1.HoldTime, n2.HoldTime, defaultHoldTime) {
 		return fmt.Errorf("multiple hold times specified for %s", neighborKey)
 	}
 
-	if !ptrsEqual(n1.KeepaliveTime, n2.KeepaliveTime, uint64(60*time.Second)) {
+	if !ptrsEqual(n1.KeepaliveTime, n2.KeepaliveTime, defaultKeepaliveTime) {
 		return fmt.Errorf("multiple keepalive times specified for %s", neighborKey)
 	}
 
-	if !ptrsEqual(n1.ConnectTime, n2.ConnectTime, uint64(60*time.Second)) {
+	if !ptrsEqual(n1.ConnectTime, n2.ConnectTime, defaultConnectTime) {
 		return fmt.Errorf("multiple connect times specified for %s", neighborKey)
 	}
 

--- a/internal/controller/merge_test.go
+++ b/internal/controller/merge_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/metallb/frr-k8s/internal/frr"
 	"github.com/metallb/frr-k8s/internal/ipfamily"
+	"k8s.io/utils/ptr"
 )
 
 func TestMergeRouters(t *testing.T) {
@@ -1290,6 +1291,45 @@ func TestMergeNeighbors(t *testing.T) {
 				},
 			},
 			err: fmt.Errorf("multiple local prefs specified for prefix %s", "192.0.2.0/24"),
+		},
+		{
+			name: "HoldTime / KeepAlive time, one nil, the other specifies the default",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      65040,
+					Addr:     "192.0.1.20",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily:      ipfamily.IPv4,
+					Name:          "65040@192.0.1.20",
+					ASN:           65040,
+					Addr:          "192.0.1.20",
+					HoldTime:      ptr.To(uint64(180)),
+					KeepaliveTime: ptr.To(uint64(60)),
+					ConnectTime:   ptr.To(uint64(60)),
+				},
+			},
+			expected: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      65040,
+					Addr:     "192.0.1.20",
+					Outgoing: frr.AllowedOut{
+						PrefixesV4: []frr.OutgoingFilter{},
+						PrefixesV6: []frr.OutgoingFilter{},
+					},
+					Incoming: frr.AllowedIn{
+						PrefixesV4: []frr.IncomingFilter{},
+						PrefixesV6: []frr.IncomingFilter{},
+					},
+				},
+			},
+			err: nil,
 		},
 	}
 


### PR DESCRIPTION
The target is already expressed in seconds, so we must
consider the default directly expressed in seconds.