### PR TITLE
Expose src addr in the k8s API

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -226,6 +226,7 @@ _Appears in:_
 | Field | Description |
 | --- | --- |
 | `asn` _integer_ | ASN is the AS number to use for the local end of the session. |
+| `sourceaddress` _string_ | SourceAddress is the IPv4 or IPv6 source address to use for the BGP session to this neighbour, may be specified as either an IP address directly or as an interface name |
 | `address` _string_ | Address is the IP address to establish the session with. |
 | `port` _integer_ | Port is the port to dial when establishing the session. Defaults to 179. |
 | `password` _string_ | Password to be used for establishing the BGP session. Password and PasswordSecret are mutually exclusive. |

--- a/api/v1beta1/frrconfiguration_types.go
+++ b/api/v1beta1/frrconfiguration_types.go
@@ -89,6 +89,12 @@ type Neighbor struct {
 	// +kubebuilder:validation:Maximum=4294967295
 	ASN uint32 `json:"asn"`
 
+	// SourceAddress is the IPv4 or IPv6 source address to use for the BGP
+	// session to this neighbour, may be specified as either an IP address
+	// directly or as an interface name
+	// +optional
+	SourceAddress string `json:"sourceaddress,omitempty"`
+
 	// Address is the IP address to establish the session with.
 	Address string `json:"address"`
 

--- a/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
@@ -205,6 +205,12 @@ spec:
                                 maximum: 16384
                                 minimum: 0
                                 type: integer
+                              sourceaddress:
+                                description: |-
+                                  SourceAddress is the IPv4 or IPv6 source address to use for the BGP
+                                  session to this neighbour, may be specified as either an IP address
+                                  directly or as an interface name
+                                type: string
                               toAdvertise:
                                 description: ToAdvertise represents the list of prefixes
                                   to advertise to the given neighbor and the associated

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -220,6 +220,12 @@ spec:
                                 maximum: 16384
                                 minimum: 0
                                 type: integer
+                              sourceaddress:
+                                description: |-
+                                  SourceAddress is the IPv4 or IPv6 source address to use for the BGP
+                                  session to this neighbour, may be specified as either an IP address
+                                  directly or as an interface name
+                                type: string
                               toAdvertise:
                                 description: ToAdvertise represents the list of prefixes
                                   to advertise to the given neighbor and the associated

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -220,6 +220,12 @@ spec:
                                 maximum: 16384
                                 minimum: 0
                                 type: integer
+                              sourceaddress:
+                                description: |-
+                                  SourceAddress is the IPv4 or IPv6 source address to use for the BGP
+                                  session to this neighbour, may be specified as either an IP address
+                                  directly or as an interface name
+                                type: string
                               toAdvertise:
                                 description: ToAdvertise represents the list of prefixes
                                   to advertise to the given neighbor and the associated

--- a/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
@@ -205,6 +205,12 @@ spec:
                                 maximum: 16384
                                 minimum: 0
                                 type: integer
+                              sourceaddress:
+                                description: |-
+                                  SourceAddress is the IPv4 or IPv6 source address to use for the BGP
+                                  session to this neighbour, may be specified as either an IP address
+                                  directly or as an interface name
+                                type: string
                               toAdvertise:
                                 description: ToAdvertise represents the list of prefixes
                                   to advertise to the given neighbor and the associated

--- a/internal/controller/api_to_config.go
+++ b/internal/controller/api_to_config.go
@@ -139,6 +139,7 @@ func neighborToFRR(n v1beta1.Neighbor, ipv4Prefixes, ipv6Prefixes []string, alwa
 	res := &frr.NeighborConfig{
 		Name:         neighborName(n.ASN, n.Address),
 		ASN:          n.ASN,
+		SrcAddr:      n.SourceAddress,
 		Addr:         n.Address,
 		Port:         n.Port,
 		IPFamily:     neighborFamily,

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -521,6 +521,7 @@ func TestMultipleNeighborsOneV4AndOneV6(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						ASN:      65001,
+						SrcAddr:  "192.168.1.50",
 						Addr:     "192.168.1.2",
 						Outgoing: AllowedOut{
 							PrefixesV4: []OutgoingFilter{

--- a/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6.golden
+++ b/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6.golden
@@ -67,7 +67,7 @@ router bgp 65000
   
   
   
-  
+  neighbor 192.168.1.2 update-source 192.168.1.50
   neighbor 2001:db8::1 remote-as 65002
   neighbor 2001:db8::1 ebgp-multihop
   


### PR DESCRIPTION
/kind feature

```release-note
Expose the IPv4 or IPv6 source address to use for the BGP session through the k8s API
```

Fixes https://github.com/metallb/frr-k8s/issues/132