### PR TITLE
Make the frr generated files compatible with 8.0+

### DIFF
--- a/charts/frr-k8s/templates/controller.yaml
+++ b/charts/frr-k8s/templates/controller.yaml
@@ -95,7 +95,7 @@ data:
   frr.conf: |+
     ! This file gets overriden the first time the speaker renders a config.
     ! So anything configured here is only temporary.
-    frr version 7.5.1
+    frr version 8.0
     frr defaults traditional
     hostname Router
     line vty

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -849,7 +849,7 @@ data:
   frr.conf: |
     ! This file gets overriden the first time the speaker renders a config.
     ! So anything configured here is only temporary.
-    frr version 7.5.1
+    frr version 8.0
     frr defaults traditional
     hostname Router
     line vty

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -818,7 +818,7 @@ data:
   frr.conf: |
     ! This file gets overriden the first time the speaker renders a config.
     ! So anything configured here is only temporary.
-    frr version 7.5.1
+    frr version 8.0
     frr defaults traditional
     hostname Router
     line vty

--- a/config/frr-k8s/frr-cm.yaml
+++ b/config/frr-k8s/frr-cm.yaml
@@ -91,7 +91,7 @@ data:
   frr.conf: |+
     ! This file gets overriden the first time the speaker renders a config.
     ! So anything configured here is only temporary.
-    frr version 7.5.1
+    frr version 8.0
     frr defaults traditional
     hostname Router
     line vty

--- a/internal/frr/templates/bfdprofile.tmpl
+++ b/internal/frr/templates/bfdprofile.tmpl
@@ -13,7 +13,8 @@
     echo-mode
     {{end -}}
     {{ if .profile.EchoInterval -}}
-    echo-interval {{.profile.EchoInterval}}
+    echo transmit-interval {{.profile.EchoInterval}}
+    echo receive-interval {{.profile.EchoInterval}}
     {{end -}}
     {{ if .profile.PassiveMode -}}
     passive-mode

--- a/internal/frr/testdata/TestSingleSessionBFD.golden
+++ b/internal/frr/testdata/TestSingleSessionBFD.golden
@@ -57,7 +57,8 @@ bfd
     transmit-interval 200
     detect-multiplier 3
     echo-mode
-    echo-interval 25
+    echo transmit-interval 25
+    echo receive-interval 25
     passive-mode
     minimum-ttl 20
     

--- a/internal/frr/testdata/TestTwoRoutersTwoNeighborsBFD.golden
+++ b/internal/frr/testdata/TestTwoRoutersTwoNeighborsBFD.golden
@@ -102,7 +102,8 @@ bfd
     transmit-interval 200
     detect-multiplier 3
     echo-mode
-    echo-interval 25
+    echo transmit-interval 25
+    echo receive-interval 25
     passive-mode
     minimum-ttl 20
     


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

FRR 8 preferred format for bfd echo-intervals is with separate transmit
/ receive timers. FRR 9.1 actually reports an error when deleting the
echo interval stanza.

Here we:
- generate an frr 8.0+ compatible frr configuration file
- declare the format of the configuration file to be 8.0 compatible

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Make the generated frr file compatible with frr 8+: split bfd echo interval in echo tx / echo rx.
```
