### PR TITLE
Revert "E2E: verify frrk8s daemonset is ready before tests"

### DIFF
--- a/e2etests/e2etest_suite_test.go
+++ b/e2etests/e2etest_suite_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/metallb/frrk8stests/pkg/dump"
 	"github.com/metallb/frrk8stests/pkg/infra"
-	"github.com/metallb/frrk8stests/pkg/k8s"
 	"github.com/metallb/frrk8stests/pkg/k8sclient"
 	"github.com/metallb/frrk8stests/tests"
 	"github.com/onsi/ginkgo/v2"
@@ -87,10 +86,6 @@ var _ = ginkgo.BeforeSuite(func() {
 	}
 
 	tests.PrometheusNamespace = prometheusNamespace
-
-	h, err := k8s.FRRK8isDaemonSetReady(cs)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(h).Should(BeTrue(), "frr-k8s daemonset should be ready before test")
 })
 
 var _ = ginkgo.AfterSuite(func() {

--- a/e2etests/pkg/k8s/pods.go
+++ b/e2etests/pkg/k8s/pods.go
@@ -4,7 +4,6 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"time"
 
@@ -88,25 +87,4 @@ func podIsRunningAndReady(pod *v1.Pod) bool {
 	}
 
 	return true
-}
-
-func FRRK8isDaemonSetReady(clientset clientset.Interface) (bool, error) {
-
-	// common labels in helm, kustomize
-	l := "app.kubernetes.io/component=frr-k8s,app.kubernetes.io/name=frr-k8s"
-	dss, err := clientset.AppsV1().DaemonSets(FRRK8sNamespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: l,
-	})
-	if len(dss.Items) != 1 {
-		return false, fmt.Errorf("found more or less than single daemonset")
-	}
-
-	n := dss.Items[0].Name
-	ds, err := clientset.AppsV1().DaemonSets(FRRK8sNamespace).Get(context.Background(),
-		n, metav1.GetOptions{})
-	if err != nil {
-		return false, err
-	}
-
-	return ds.Status.DesiredNumberScheduled == ds.Status.NumberAvailable, nil
 }


### PR DESCRIPTION
 /kind regression
because it depends on labels, and running the test suite outside that repo (e.g. as part of the operator) might not work

**What this PR does / why we need it**:


```release-note
NONE
```
