### PR TITLE
Add support for "Dynamic ASN"

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -122,6 +122,19 @@ _Appears in:_
 | `community` _string_ | Community is the community associated to the prefixes. |  |  |
 
 
+#### DynamicASNMode
+
+_Underlying type:_ _string_
+
+
+
+
+
+_Appears in:_
+- [Neighbor](#neighbor)
+
+
+
 #### FRRConfiguration
 
 
@@ -268,7 +281,8 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `asn` _integer_ | ASN is the AS number to use for the local end of the session. |  | Maximum: 4.294967295e+09 <br />Minimum: 0 <br /> |
+| `asn` _integer_ | ASN is the AS number to use for the local end of the session.<br />ASN and DynamicASN are mutually exclusive and one of them must be specified. |  | Maximum: 4.294967295e+09 <br />Minimum: 0 <br /> |
+| `dynamicASN` _[DynamicASNMode](#dynamicasnmode)_ | DynamicASN detects the AS number to use for the local end of the session<br />without explicitly setting it via the ASN field. Limited to:<br />internal - if the neighbor's ASN is different than the router's the connection is denied.<br />external - if the neighbor's ASN is the same as the router's the connection is denied.<br />ASN and DynamicASN are mutually exclusive and one of them must be specified. |  | Enum: [internal external] <br /> |
 | `sourceaddress` _string_ | SourceAddress is the IPv4 or IPv6 source address to use for the BGP<br />session to this neighbour, may be specified as either an IP address<br />directly or as an interface name |  |  |
 | `address` _string_ | Address is the IP address to establish the session with. |  |  |
 | `port` _integer_ | Port is the port to dial when establishing the session.<br />Defaults to 179. |  | Maximum: 16384 <br />Minimum: 0 <br /> |

--- a/api/v1beta1/frrconfiguration_types.go
+++ b/api/v1beta1/frrconfiguration_types.go
@@ -95,9 +95,20 @@ type Import struct {
 // Neighbor represents a BGP Neighbor we want FRR to connect to.
 type Neighbor struct {
 	// ASN is the AS number to use for the local end of the session.
+	// ASN and DynamicASN are mutually exclusive and one of them must be specified.
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4294967295
-	ASN uint32 `json:"asn"`
+	// +optional
+	ASN uint32 `json:"asn,omitempty"`
+
+	// DynamicASN detects the AS number to use for the local end of the session
+	// without explicitly setting it via the ASN field. Limited to:
+	// internal - if the neighbor's ASN is different than the router's the connection is denied.
+	// external - if the neighbor's ASN is the same as the router's the connection is denied.
+	// ASN and DynamicASN are mutually exclusive and one of them must be specified.
+	// +kubebuilder:validation:Enum=internal;external
+	// +optional
+	DynamicASN DynamicASNMode `json:"dynamicASN,omitempty"`
 
 	// SourceAddress is the IPv4 or IPv6 source address to use for the BGP
 	// session to this neighbour, may be specified as either an IP address
@@ -370,4 +381,11 @@ type AllowMode string
 const (
 	AllowAll        AllowMode = "all"
 	AllowRestricted AllowMode = "filtered"
+)
+
+type DynamicASNMode string
+
+const (
+	InternalASNMode DynamicASNMode = "internal"
+	ExternalASNMode DynamicASNMode = "external"
 )

--- a/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
@@ -156,8 +156,9 @@ spec:
                                   the session with.
                                 type: string
                               asn:
-                                description: ASN is the AS number to use for the local
-                                  end of the session.
+                                description: |-
+                                  ASN is the AS number to use for the local end of the session.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                                 format: int32
                                 maximum: 4294967295
                                 minimum: 0
@@ -187,6 +188,17 @@ spec:
                                   will separate IPv4 and IPv6 route exchanges into
                                   distinct BGP sessions.
                                 type: boolean
+                              dynamicASN:
+                                description: |-
+                                  DynamicASN detects the AS number to use for the local end of the session
+                                  without explicitly setting it via the ASN field. Limited to:
+                                  internal - if the neighbor's ASN is different than the router's the connection is denied.
+                                  external - if the neighbor's ASN is the same as the router's the connection is denied.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                                enum:
+                                - internal
+                                - external
+                                type: string
                               ebgpMultiHop:
                                 description: EBGPMultiHop indicates if the BGPPeer
                                   is multi-hops away.
@@ -366,7 +378,6 @@ spec:
                                 type: object
                             required:
                             - address
-                            - asn
                             type: object
                           type: array
                         prefixes:

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -171,8 +171,9 @@ spec:
                                   the session with.
                                 type: string
                               asn:
-                                description: ASN is the AS number to use for the local
-                                  end of the session.
+                                description: |-
+                                  ASN is the AS number to use for the local end of the session.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                                 format: int32
                                 maximum: 4294967295
                                 minimum: 0
@@ -202,6 +203,17 @@ spec:
                                   will separate IPv4 and IPv6 route exchanges into
                                   distinct BGP sessions.
                                 type: boolean
+                              dynamicASN:
+                                description: |-
+                                  DynamicASN detects the AS number to use for the local end of the session
+                                  without explicitly setting it via the ASN field. Limited to:
+                                  internal - if the neighbor's ASN is different than the router's the connection is denied.
+                                  external - if the neighbor's ASN is the same as the router's the connection is denied.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                                enum:
+                                - internal
+                                - external
+                                type: string
                               ebgpMultiHop:
                                 description: EBGPMultiHop indicates if the BGPPeer
                                   is multi-hops away.
@@ -381,7 +393,6 @@ spec:
                                 type: object
                             required:
                             - address
-                            - asn
                             type: object
                           type: array
                         prefixes:

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -171,8 +171,9 @@ spec:
                                   the session with.
                                 type: string
                               asn:
-                                description: ASN is the AS number to use for the local
-                                  end of the session.
+                                description: |-
+                                  ASN is the AS number to use for the local end of the session.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                                 format: int32
                                 maximum: 4294967295
                                 minimum: 0
@@ -202,6 +203,17 @@ spec:
                                   will separate IPv4 and IPv6 route exchanges into
                                   distinct BGP sessions.
                                 type: boolean
+                              dynamicASN:
+                                description: |-
+                                  DynamicASN detects the AS number to use for the local end of the session
+                                  without explicitly setting it via the ASN field. Limited to:
+                                  internal - if the neighbor's ASN is different than the router's the connection is denied.
+                                  external - if the neighbor's ASN is the same as the router's the connection is denied.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                                enum:
+                                - internal
+                                - external
+                                type: string
                               ebgpMultiHop:
                                 description: EBGPMultiHop indicates if the BGPPeer
                                   is multi-hops away.
@@ -381,7 +393,6 @@ spec:
                                 type: object
                             required:
                             - address
-                            - asn
                             type: object
                           type: array
                         prefixes:

--- a/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
@@ -156,8 +156,9 @@ spec:
                                   the session with.
                                 type: string
                               asn:
-                                description: ASN is the AS number to use for the local
-                                  end of the session.
+                                description: |-
+                                  ASN is the AS number to use for the local end of the session.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
                                 format: int32
                                 maximum: 4294967295
                                 minimum: 0
@@ -187,6 +188,17 @@ spec:
                                   will separate IPv4 and IPv6 route exchanges into
                                   distinct BGP sessions.
                                 type: boolean
+                              dynamicASN:
+                                description: |-
+                                  DynamicASN detects the AS number to use for the local end of the session
+                                  without explicitly setting it via the ASN field. Limited to:
+                                  internal - if the neighbor's ASN is different than the router's the connection is denied.
+                                  external - if the neighbor's ASN is the same as the router's the connection is denied.
+                                  ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                                enum:
+                                - internal
+                                - external
+                                type: string
                               ebgpMultiHop:
                                 description: EBGPMultiHop indicates if the BGPPeer
                                   is multi-hops away.
@@ -366,7 +378,6 @@ spec:
                                 type: object
                             required:
                             - address
-                            - asn
                             type: object
                           type: array
                         prefixes:

--- a/e2etests/tests/webhooks.go
+++ b/e2etests/tests/webhooks.go
@@ -88,6 +88,7 @@ var _ = ginkgo.Describe("Webhooks", func() {
 							ASN: 100,
 							Neighbors: []frrk8sv1beta1.Neighbor{
 								{
+									ASN:     100,
 									Address: "192.a.b.10",
 								},
 							},
@@ -102,6 +103,7 @@ var _ = ginkgo.Describe("Webhooks", func() {
 						{
 							Neighbors: []frrk8sv1beta1.Neighbor{
 								{
+									ASN:     100,
 									Address: "1.2.3.4",
 									ToAdvertise: frrk8sv1beta1.Advertise{
 										PrefixesWithLocalPref: []frrk8sv1beta1.LocalPrefPrefixes{
@@ -117,6 +119,36 @@ var _ = ginkgo.Describe("Webhooks", func() {
 					}
 				},
 				"localPref associated to non existing prefix",
+			),
+			ginkgo.Entry("both asn and dynamicASN not specified",
+				func(cfg *frrk8sv1beta1.FRRConfiguration) {
+					cfg.Spec.BGP.Routers = []frrk8sv1beta1.Router{
+						{
+							Neighbors: []frrk8sv1beta1.Neighbor{
+								{
+									Address: "1.2.3.4",
+								},
+							},
+						},
+					}
+				},
+				"has no ASN or DynamicASN specified",
+			),
+			ginkgo.Entry("both asn and dynamicASN specified",
+				func(cfg *frrk8sv1beta1.FRRConfiguration) {
+					cfg.Spec.BGP.Routers = []frrk8sv1beta1.Router{
+						{
+							Neighbors: []frrk8sv1beta1.Neighbor{
+								{
+									ASN:        100,
+									DynamicASN: frrk8sv1beta1.ExternalASNMode,
+									Address:    "1.2.3.4",
+								},
+							},
+						},
+					}
+				},
+				"has both ASN and DynamicASN specified",
 			),
 		)
 

--- a/internal/controller/api_to_config_test.go
+++ b/internal/controller/api_to_config_test.go
@@ -79,7 +79,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily:        ipfamily.IPv4,
 								Name:            "65002@192.0.2.2",
-								ASN:             65002,
+								ASN:             "65002",
 								Port:            ptr.To[uint16](179),
 								SrcAddr:         "192.1.1.1",
 								Addr:            "192.0.2.2",
@@ -141,7 +141,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily:      ipfamily.IPv4,
 								Name:          "65002@192.0.2.2",
-								ASN:           65002,
+								ASN:           "65002",
 								Port:          ptr.To[uint16](179),
 								Addr:          "192.0.2.2",
 								KeepaliveTime: ptr.To[uint64](20),
@@ -205,13 +205,13 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65011@192.0.2.6",
-								ASN:      65011,
+								ASN:      "65011",
 								Addr:     "192.0.2.6",
 							},
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65012@192.0.2.7",
-								ASN:      65012,
+								ASN:      "65012",
 								Addr:     "192.0.2.7",
 							},
 						},
@@ -224,7 +224,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv6,
 								Name:     "65014@2001:db8::4",
-								ASN:      65014,
+								ASN:      "65014",
 								Addr:     "2001:db8::4",
 								VRFName:  "vrf2",
 							},
@@ -270,7 +270,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65021@192.0.2.11",
-								ASN:      65021,
+								ASN:      "65021",
 								Addr:     "192.0.2.11",
 							},
 						},
@@ -324,7 +324,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65031@192.0.2.16",
-								ASN:      65031,
+								ASN:      "65031",
 								Addr:     "192.0.2.16",
 								VRFName:  "vrf1",
 							},
@@ -375,7 +375,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.21",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.21",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -441,7 +441,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.21",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.21",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -459,7 +459,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.22",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.22",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -586,7 +586,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.21",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.21",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -615,7 +615,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.22",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.22",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -880,7 +880,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.21",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.21",
 								Incoming: frr.AllowedIn{
 									All: true,
@@ -936,7 +936,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.21",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.21",
 								Incoming: frr.AllowedIn{
 									All: false,
@@ -1000,7 +1000,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.21",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.21",
 								Incoming: frr.AllowedIn{
 									All: false,
@@ -1141,7 +1141,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65012@192.0.2.7",
-								ASN:      65012,
+								ASN:      "65012",
 								Addr:     "192.0.2.7",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -1252,7 +1252,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65012@192.0.2.7",
-								ASN:      65012,
+								ASN:      "65012",
 								Addr:     "192.0.2.7",
 								Incoming: frr.AllowedIn{
 									PrefixesV4: []frr.IncomingFilter{
@@ -1446,7 +1446,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65011@192.0.2.6",
-								ASN:      65011,
+								ASN:      "65011",
 								Addr:     "192.0.2.6",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -1464,7 +1464,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65012@192.0.2.7",
-								ASN:      65012,
+								ASN:      "65012",
 								Addr:     "192.0.2.7",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -1504,7 +1504,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65017@192.0.2.7",
-								ASN:      65017,
+								ASN:      "65017",
 								Addr:     "192.0.2.7",
 								VRFName:  "vrf2",
 								Outgoing: frr.AllowedOut{
@@ -1519,7 +1519,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv6,
 								Name:     "65014@2001:db8::4",
-								ASN:      65014,
+								ASN:      "65014",
 								Addr:     "2001:db8::4",
 								VRFName:  "vrf2",
 								Outgoing: frr.AllowedOut{
@@ -1624,14 +1624,14 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65012@192.0.2.7",
-								ASN:      65012,
+								ASN:      "65012",
 								Addr:     "192.0.2.7",
 								Password: "password1",
 							},
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65012@192.0.2.8",
-								ASN:      65012,
+								ASN:      "65012",
 								Addr:     "192.0.2.8",
 								Password: "cleartext-password",
 							},
@@ -1645,14 +1645,14 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65017@192.0.2.7",
-								ASN:      65017,
+								ASN:      "65017",
 								Addr:     "192.0.2.7",
 								VRFName:  "vrf2",
 							},
 							{
 								IPFamily: ipfamily.IPv6,
 								Name:     "65014@2001:db8::4",
-								ASN:      65014,
+								ASN:      "65014",
 								Addr:     "2001:db8::4",
 								VRFName:  "vrf2",
 								Password: "password2",
@@ -1866,7 +1866,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily:   ipfamily.IPv4,
 								Name:       "65041@192.0.2.21",
-								ASN:        65041,
+								ASN:        "65041",
 								Addr:       "192.0.2.21",
 								BFDProfile: "bfd1",
 							},
@@ -2183,7 +2183,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65011@192.0.2.6",
-								ASN:      65011,
+								ASN:      "65011",
 								Addr:     "192.0.2.6",
 								AlwaysBlock: []frr.IncomingFilter{
 									{
@@ -2206,7 +2206,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv6,
 								Name:     "65014@2001:db8::4",
-								ASN:      65014,
+								ASN:      "65014",
 								Addr:     "2001:db8::4",
 								VRFName:  "vrf2",
 								AlwaysBlock: []frr.IncomingFilter{
@@ -2328,7 +2328,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.21",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.21",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -2346,7 +2346,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.22",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.22",
 								Outgoing: frr.AllowedOut{
 									PrefixesV4: []frr.OutgoingFilter{
@@ -2466,7 +2466,7 @@ func TestConversion(t *testing.T) {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65041@192.0.2.22",
-								ASN:      65041,
+								ASN:      "65041",
 								Addr:     "192.0.2.22",
 								VRFName:  "red",
 								Outgoing: frr.AllowedOut{
@@ -2498,6 +2498,135 @@ func TestConversion(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name: "Neighbor without ASN or DynamicASN",
+			fromK8s: []v1beta1.FRRConfiguration{
+				{
+					Spec: v1beta1.FRRConfigurationSpec{
+						BGP: v1beta1.BGPConfig{
+							Routers: []v1beta1.Router{
+								{
+									ASN: 65010,
+									ID:  "192.0.2.5",
+									VRF: "",
+									Neighbors: []v1beta1.Neighbor{
+										{
+											Address: "192.0.2.22",
+											ToAdvertise: v1beta1.Advertise{
+												Allowed: v1beta1.AllowedOutPrefixes{
+													Mode: v1beta1.AllowAll,
+												},
+											},
+										},
+									},
+									Prefixes: []string{"192.0.2.0/24", "2001:db8::/64"},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: map[string]v1.Secret{},
+			err:     errors.New("65010-: neighbor 0@192.0.2.22 has no ASN or DynamicASN specified"),
+		},
+		{
+			name: "Neighbor with both ASN and DynamicASN",
+			fromK8s: []v1beta1.FRRConfiguration{
+				{
+					Spec: v1beta1.FRRConfigurationSpec{
+						BGP: v1beta1.BGPConfig{
+							Routers: []v1beta1.Router{
+								{
+									ASN: 65010,
+									ID:  "192.0.2.5",
+									VRF: "",
+									Neighbors: []v1beta1.Neighbor{
+										{
+											Address:    "192.0.2.22",
+											ASN:        65010,
+											DynamicASN: "internal",
+											ToAdvertise: v1beta1.Advertise{
+												Allowed: v1beta1.AllowedOutPrefixes{
+													Mode: v1beta1.AllowAll,
+												},
+											},
+										},
+									},
+									Prefixes: []string{"192.0.2.0/24", "2001:db8::/64"},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: map[string]v1.Secret{},
+			err:     errors.New("neighbor internal@192.0.2.22 has both ASN and DynamicASN specified"),
+		},
+		{
+			name: "Neighbor with DynamicASN",
+			fromK8s: []v1beta1.FRRConfiguration{
+				{
+					Spec: v1beta1.FRRConfigurationSpec{
+						BGP: v1beta1.BGPConfig{
+							Routers: []v1beta1.Router{
+								{
+									ASN: 65010,
+									ID:  "192.0.2.5",
+									VRF: "",
+									Neighbors: []v1beta1.Neighbor{
+										{
+											Address:    "192.0.2.22",
+											DynamicASN: "internal",
+											ToAdvertise: v1beta1.Advertise{
+												Allowed: v1beta1.AllowedOutPrefixes{
+													Mode: v1beta1.AllowAll,
+												},
+											},
+										},
+									},
+									Prefixes: []string{"192.0.2.0/24", "2001:db8::/64"},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &frr.Config{
+				Routers: []*frr.RouterConfig{
+					{
+						MyASN:    65010,
+						VRF:      "",
+						RouterID: "192.0.2.5",
+						Neighbors: []*frr.NeighborConfig{
+							{
+								IPFamily: ipfamily.IPv4,
+								Name:     "internal@192.0.2.22",
+								ASN:      "internal",
+								Addr:     "192.0.2.22",
+								Outgoing: frr.AllowedOut{
+									PrefixesV4: []frr.OutgoingFilter{
+										{
+											IPFamily: ipfamily.IPv4,
+											Prefix:   "192.0.2.0/24",
+										},
+									},
+									PrefixesV6: []frr.OutgoingFilter{
+										{
+											IPFamily: ipfamily.IPv6,
+											Prefix:   "2001:db8::/64",
+										},
+									},
+								},
+							},
+						},
+						IPV4Prefixes: []string{"192.0.2.0/24"},
+						IPV6Prefixes: []string{"2001:db8::/64"},
+					},
+				},
+			},
+			secrets: map[string]v1.Secret{},
+			err:     nil,
 		},
 	}
 

--- a/internal/controller/frrconfiguration_controller_test.go
+++ b/internal/controller/frrconfiguration_controller_test.go
@@ -548,7 +548,7 @@ var _ = Describe("Frrk8s controller", func() {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65012@192.0.2.7",
-								ASN:      65012,
+								ASN:      "65012",
 								Addr:     "192.0.2.7",
 								Password: "password2",
 								Outgoing: frr.AllowedOut{
@@ -585,7 +585,7 @@ var _ = Describe("Frrk8s controller", func() {
 							{
 								IPFamily: ipfamily.IPv4,
 								Name:     "65012@192.0.2.7",
-								ASN:      65012,
+								ASN:      "65012",
 								Addr:     "192.0.2.7",
 								Password: "password3",
 								Outgoing: frr.AllowedOut{

--- a/internal/controller/merge_test.go
+++ b/internal/controller/merge_test.go
@@ -31,7 +31,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.20",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.20",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -68,7 +68,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.21",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.21",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -105,7 +105,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.22",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.22",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -153,7 +153,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.20",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.20",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -201,7 +201,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.21",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.21",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -249,7 +249,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.23",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.23",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -306,7 +306,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.20",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.20",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -356,7 +356,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.21",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.21",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -406,7 +406,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.22",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.22",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -443,7 +443,7 @@ func TestMergeRouters(t *testing.T) {
 					{
 						IPFamily: ipfamily.IPv4,
 						Name:     "65040@192.0.1.23",
-						ASN:      65040,
+						ASN:      "65040",
 						Addr:     "192.0.1.23",
 						Outgoing: frr.AllowedOut{
 							PrefixesV4: []frr.OutgoingFilter{
@@ -560,7 +560,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -599,7 +599,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -649,7 +649,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -705,7 +705,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -742,7 +742,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.21",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.21",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -779,7 +779,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.22",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.22",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -818,7 +818,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -866,7 +866,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.21",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.21",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -914,7 +914,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.23",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.23",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -964,7 +964,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -1014,7 +1014,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.21",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.21",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -1064,7 +1064,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.22",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.22",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -1101,7 +1101,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.23",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.23",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -1155,7 +1155,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Incoming: frr.AllowedIn{
 						All:        true,
@@ -1168,7 +1168,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Incoming: frr.AllowedIn{
 						All: false,
@@ -1186,7 +1186,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{},
@@ -1207,7 +1207,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Incoming: frr.AllowedIn{
 						All: false,
@@ -1225,7 +1225,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Incoming: frr.AllowedIn{
 						All:        true,
@@ -1238,7 +1238,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{},
@@ -1259,7 +1259,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -1277,7 +1277,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{
@@ -1299,7 +1299,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 				},
 			},
@@ -1307,7 +1307,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily:      ipfamily.IPv4,
 					Name:          "65040@192.0.1.20",
-					ASN:           65040,
+					ASN:           "65040",
 					Addr:          "192.0.1.20",
 					HoldTime:      ptr.To(uint64(180)),
 					KeepaliveTime: ptr.To(uint64(60)),
@@ -1318,7 +1318,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 					Outgoing: frr.AllowedOut{
 						PrefixesV4: []frr.OutgoingFilter{},
@@ -1339,7 +1339,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily:      ipfamily.IPv4,
 					Name:          "65040@192.0.1.20",
-					ASN:           65040,
+					ASN:           "65040",
 					Addr:          "192.0.1.20",
 					HoldTime:      ptr.To(uint64(180)),
 					KeepaliveTime: ptr.To(uint64(60)),
@@ -1350,7 +1350,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 				},
 			},
@@ -1358,7 +1358,7 @@ func TestMergeNeighbors(t *testing.T) {
 				{
 					IPFamily: ipfamily.IPv4,
 					Name:     "65040@192.0.1.20",
-					ASN:      65040,
+					ASN:      "65040",
 					Addr:     "192.0.1.20",
 				},
 			},

--- a/internal/frr/config.go
+++ b/internal/frr/config.go
@@ -65,7 +65,7 @@ type BFDProfile struct {
 type NeighborConfig struct {
 	IPFamily        ipfamily.Family
 	Name            string
-	ASN             uint32
+	ASN             string
 	SrcAddr         string
 	Addr            string
 	Port            *uint16
@@ -187,11 +187,33 @@ func templateConfig(data interface{}) (string, error) {
 			"deniedIncomingList": func(neighbor *NeighborConfig) string {
 				return fmt.Sprintf("%s-denied-inpl-%s", neighbor.ID(), neighbor.IPFamily)
 			},
-			"mustDisableConnectedCheck": func(ipFamily ipfamily.Family, myASN, asn uint32, eBGPMultiHop bool) bool {
-				// return true only for IPv6 eBGP sessions
-				if ipFamily == "ipv6" && myASN != asn && !eBGPMultiHop {
+			"mustDisableConnectedCheck": func(ipFamily ipfamily.Family, myASN uint32, asn string, eBGPMultiHop bool) bool {
+				// return true only for non-multihop IPv6 eBGP sessions
+
+				if ipFamily != ipfamily.IPv6 {
+					return false
+				}
+
+				if eBGPMultiHop {
+					return false
+				}
+
+				// internal means we expect the session to be iBGP
+				if asn == "internal" {
+					return false
+				}
+
+				// external means we expect the session to be eBGP
+				if asn == "external" {
 					return true
 				}
+
+				// the peer's asn is not dynamic (it is a number),
+				// we check if it is different than ours for eBGP
+				if strconv.FormatUint(uint64(myASN), 10) != asn {
+					return true
+				}
+
 				return false
 			},
 			"dict": func(values ...interface{}) (map[string]interface{}, error) {

--- a/internal/frr/frr_bfd_test.go
+++ b/internal/frr/frr_bfd_test.go
@@ -25,7 +25,7 @@ func TestSingleSessionBFD(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:   ipfamily.IPv4,
-						ASN:        65001,
+						ASN:        "65001",
 						Addr:       "192.168.1.2",
 						BFDProfile: "test",
 					},
@@ -68,7 +68,7 @@ func TestTwoRoutersTwoNeighborsBFD(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.2",
 					},
 				},
@@ -79,7 +79,7 @@ func TestTwoRoutersTwoNeighborsBFD(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:   ipfamily.IPv4,
-						ASN:        65001,
+						ASN:        "65001",
 						Addr:       "192.168.1.3",
 						BFDProfile: "testdefault",
 					},

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -110,7 +110,7 @@ func TestSingleSession(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.2",
 						Port:     ptr.To[uint16](4567),
 						Outgoing: AllowedOut{
@@ -152,7 +152,7 @@ func TestTwoRoutersTwoNeighbors(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:      ipfamily.IPv4,
-						ASN:           65001,
+						ASN:           "65001",
 						Addr:          "192.168.1.2",
 						HoldTime:      ptr.To[uint64](80),
 						KeepaliveTime: ptr.To[uint64](40),
@@ -189,7 +189,7 @@ func TestTwoRoutersTwoNeighbors(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.3",
 						Outgoing: AllowedOut{
 							PrefixesV4: []OutgoingFilter{
@@ -226,14 +226,14 @@ func TestTwoSessionsAcceptAll(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.2",
 						Incoming: AllowedIn{
 							All: true,
 						},
 					}, {
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.3",
 						Incoming: AllowedIn{
 							All: true,
@@ -264,7 +264,7 @@ func TestTwoSessionsAcceptSomeV4(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.2",
 						Incoming: AllowedIn{
 							PrefixesV4: []IncomingFilter{
@@ -276,7 +276,7 @@ func TestTwoSessionsAcceptSomeV4(t *testing.T) {
 						},
 					}, {
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.3",
 						Incoming: AllowedIn{
 							PrefixesV4: []IncomingFilter{
@@ -316,7 +316,7 @@ func TestTwoSessionsAcceptV4AndV6(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.2",
 						Incoming: AllowedIn{
 							PrefixesV4: []IncomingFilter{
@@ -348,7 +348,7 @@ func TestTwoSessionsAcceptV4AndV6(t *testing.T) {
 						},
 					}, {
 						IPFamily: ipfamily.IPv4,
-						ASN:      65002,
+						ASN:      "65002",
 						Addr:     "192.168.1.3",
 						Incoming: AllowedIn{
 							PrefixesV4: []IncomingFilter{
@@ -376,7 +376,7 @@ func TestTwoSessionsAcceptV4AndV6(t *testing.T) {
 						},
 					}, {
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.4",
 						Incoming: AllowedIn{
 							PrefixesV4: []IncomingFilter{
@@ -434,7 +434,7 @@ func TestSingleSessionWithEBGPMultihop(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:     ipfamily.IPv4,
-						ASN:          65001,
+						ASN:          "65001",
 						Addr:         "192.168.1.2",
 						EBGPMultiHop: true,
 						Outgoing: AllowedOut{
@@ -479,7 +479,7 @@ func TestSingleSessionWithIPv6SingleHop(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:     ipfamily.IPv6,
-						ASN:          65001,
+						ASN:          "65001",
 						Addr:         "2001:db8::1",
 						EBGPMultiHop: false, // Single hop
 						Outgoing: AllowedOut{
@@ -520,7 +520,7 @@ func TestMultipleNeighborsOneV4AndOneV6(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						SrcAddr:  "192.168.1.50",
 						Addr:     "192.168.1.2",
 						Outgoing: AllowedOut{
@@ -534,7 +534,7 @@ func TestMultipleNeighborsOneV4AndOneV6(t *testing.T) {
 					},
 					{
 						IPFamily:     ipfamily.IPv6,
-						ASN:          65002,
+						ASN:          "65002",
 						Addr:         "2001:db8::1",
 						EBGPMultiHop: true,
 						Outgoing: AllowedOut{
@@ -576,7 +576,7 @@ func TestMultipleNeighborsOneV4AndOneV6DisableMP(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:  ipfamily.IPv4,
-						ASN:       65001,
+						ASN:       "65001",
 						Addr:      "192.168.1.2",
 						DisableMP: true,
 						Outgoing: AllowedOut{
@@ -590,7 +590,7 @@ func TestMultipleNeighborsOneV4AndOneV6DisableMP(t *testing.T) {
 					},
 					{
 						IPFamily:     ipfamily.IPv6,
-						ASN:          65002,
+						ASN:          "65002",
 						Addr:         "2001:db8::1",
 						EBGPMultiHop: true,
 						DisableMP:    true,
@@ -633,7 +633,7 @@ func TestMultipleRoutersMultipleNeighs(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:     ipfamily.IPv4,
-						ASN:          65001,
+						ASN:          "65001",
 						Addr:         "192.168.1.2",
 						EBGPMultiHop: true,
 						Outgoing: AllowedOut{
@@ -647,7 +647,7 @@ func TestMultipleRoutersMultipleNeighs(t *testing.T) {
 					},
 					{
 						IPFamily:     ipfamily.IPv6,
-						ASN:          65002,
+						ASN:          "65002",
 						Addr:         "2001:db8::1",
 						EBGPMultiHop: true,
 						Outgoing: AllowedOut{
@@ -669,7 +669,7 @@ func TestMultipleRoutersMultipleNeighs(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.170.1.2",
 						Outgoing: AllowedOut{
 							PrefixesV4: []OutgoingFilter{
@@ -682,7 +682,7 @@ func TestMultipleRoutersMultipleNeighs(t *testing.T) {
 					},
 					{
 						IPFamily:     ipfamily.IPv6,
-						ASN:          65002,
+						ASN:          "65002",
 						Addr:         "2001:db9::1",
 						EBGPMultiHop: true,
 						Outgoing: AllowedOut{
@@ -724,7 +724,7 @@ func TestSingleSessionWithEBGPMultihopAndExtras(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:     ipfamily.IPv4,
-						ASN:          65001,
+						ASN:          "65001",
 						Addr:         "192.168.1.2",
 						EBGPMultiHop: true,
 						Outgoing: AllowedOut{
@@ -770,7 +770,7 @@ func TestSingleSessionWithAlwaysBlock(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.2",
 						Incoming: AllowedIn{
 							All: true,
@@ -790,7 +790,7 @@ func TestSingleSessionWithAlwaysBlock(t *testing.T) {
 					},
 					{
 						IPFamily: ipfamily.IPv4,
-						ASN:      65001,
+						ASN:      "65001",
 						Addr:     "192.168.1.6",
 						Incoming: AllowedIn{
 							PrefixesV4: []IncomingFilter{
@@ -841,7 +841,7 @@ func TestSingleSessionWithGracefulRestart(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:        ipfamily.IPv4,
-						ASN:             65001,
+						ASN:             "65001",
 						Addr:            "192.168.1.2",
 						GracefulRestart: true,
 					},
@@ -873,7 +873,7 @@ func TestMultipleRoutersImportVRFs(t *testing.T) {
 				Neighbors: []*NeighborConfig{
 					{
 						IPFamily:     ipfamily.IPv4,
-						ASN:          65001,
+						ASN:          "65001",
 						Addr:         "192.168.1.2",
 						EBGPMultiHop: true,
 					},
@@ -897,6 +897,90 @@ func TestMultipleRoutersImportVRFs(t *testing.T) {
 		},
 	}
 
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionWithInternalASN(t *testing.T) {
+	testSetup(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	defer cancel()
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily: ipfamily.IPv4,
+						ASN:      "internal",
+						Addr:     "192.168.1.2",
+						Port:     ptr.To[uint16](4567),
+						Outgoing: AllowedOut{
+							PrefixesV4: []OutgoingFilter{
+								{
+									IPFamily: ipfamily.IPv4,
+									Prefix:   "192.169.1.0/24",
+								},
+								{
+									IPFamily: ipfamily.IPv4,
+									Prefix:   "192.170.1.0/22",
+								},
+							},
+						},
+					},
+				},
+				IPV4Prefixes: []string{"192.169.1.0/24", "192.170.1.0/22"},
+			},
+		},
+	}
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionWithExternalASN(t *testing.T) {
+	testSetup(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	frr := NewFRR(ctx, emptyCB, log.NewNopLogger(), logging.LevelInfo)
+	defer cancel()
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily: ipfamily.IPv4,
+						ASN:      "external",
+						Addr:     "192.168.1.2",
+						Port:     ptr.To[uint16](4567),
+						Outgoing: AllowedOut{
+							PrefixesV4: []OutgoingFilter{
+								{
+									IPFamily: ipfamily.IPv4,
+									Prefix:   "192.169.1.0/24",
+								},
+								{
+									IPFamily: ipfamily.IPv4,
+									Prefix:   "192.170.1.0/22",
+								},
+							},
+						},
+					},
+				},
+				IPV4Prefixes: []string{"192.169.1.0/24", "192.170.1.0/22"},
+			},
+		},
+	}
 	err := frr.ApplyConfig(&config)
 	if err != nil {
 		t.Fatalf("Failed to apply config: %s", err)

--- a/internal/frr/testdata/TestSingleSessionWithExternalASN.golden
+++ b/internal/frr/testdata/TestSingleSessionWithExternalASN.golden
@@ -1,0 +1,65 @@
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
+
+
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 2 permit 192.170.1.0/22
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-pl-ipv4
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-pl-ipv4
+
+
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 3 deny any
+
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  neighbor 192.168.1.2 remote-as external
+  neighbor 192.168.1.2 port 4567
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 192.169.1.0/24
+    network 192.170.1.0/22
+  exit-address-family
+
+

--- a/internal/frr/testdata/TestSingleSessionWithInternalASN.golden
+++ b/internal/frr/testdata/TestSingleSessionWithInternalASN.golden
@@ -1,0 +1,65 @@
+log file /etc/frr/frr.log informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 1 permit 192.169.1.0/24
+
+
+
+ip prefix-list 192.168.1.2-pl-ipv4 seq 2 permit 192.170.1.0/22
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-pl-ipv4
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-pl-ipv4
+
+
+
+ipv6 prefix-list 192.168.1.2-pl-ipv4 seq 3 deny any
+
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  neighbor 192.168.1.2 remote-as internal
+  neighbor 192.168.1.2 port 4567
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 192.169.1.0/24
+    network 192.170.1.0/22
+  exit-address-family
+
+


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:


/kind feature

**What this PR does / why we need it**:
Adds support for FRR's "Dynamic ASN", allowing users to specify whether the peer is ibgp or ebgp without explicitly setting its asn. Leverages https://docs.frrouting.org/en/latest/bgp.html#clicmd-neighbor-PEER-remote-as-internal

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add DynamicASN field for a neighbor, which allows the daemon to detect the AS number to use without explicitly setting it. The new field is mutually exclusive with the existing ASN field, and one of them must be specified for any given Neighbor. 
```
