### PR TITLE
Remove the port from the peer metrics label

### DIFF
--- a/e2etests/tests/metrics.go
+++ b/e2etests/tests/metrics.go
@@ -384,20 +384,19 @@ func labelsForPeers(peers []*frrcontainer.FRR, ipFamily ipfamily.Family) []peerP
 		if ipFamily == ipfamily.IPv6 {
 			address = c.Ipv6
 		}
-		peerAddr := address + fmt.Sprintf(":%d", c.RouterConfig.BGPPort)
 
 		// Note: we deliberately don't add the vrf label in case of the default vrf to validate that
 		// it is still possible to list the metrics using only the peer label, which is what most users
 		// who don't care about vrfs should do.
-		labelsBGP := map[string]string{"peer": peerAddr}
-		labelsForQueryBGP := fmt.Sprintf(`peer="%s"`, peerAddr)
+		labelsBGP := map[string]string{"peer": address}
+		labelsForQueryBGP := fmt.Sprintf(`peer="%s"`, address)
 		labelsBFD := map[string]string{"peer": address}
 		labelsForQueryBFD := fmt.Sprintf(`peer="%s"`, address)
 		noEcho := c.NeighborConfig.MultiHop
 
 		if c.RouterConfig.VRF != "" {
 			labelsBGP["vrf"] = c.RouterConfig.VRF
-			labelsForQueryBGP = fmt.Sprintf(`peer="%s",vrf="%s"`, peerAddr, c.RouterConfig.VRF)
+			labelsForQueryBGP = fmt.Sprintf(`peer="%s",vrf="%s"`, address, c.RouterConfig.VRF)
 			labelsBFD["vrf"] = c.RouterConfig.VRF
 			labelsForQueryBFD = fmt.Sprintf(`peer="%s",vrf="%s"`, address, c.RouterConfig.VRF)
 		}

--- a/frr-tools/metrics/collector/bgp.go
+++ b/frr-tools/metrics/collector/bgp.go
@@ -156,7 +156,7 @@ func updateNeighborsMetrics(ch chan<- prometheus.Metric, neighbors map[string][]
 			if !n.Connected {
 				sessionUp = 0
 			}
-			peerLabel := fmt.Sprintf("%s:%d", n.IP.String(), n.Port)
+			peerLabel := n.IP.String()
 
 			ch <- prometheus.MustNewConstMetric(sessionUpDesc, prometheus.GaugeValue, float64(sessionUp), peerLabel, vrf)
 			ch <- prometheus.MustNewConstMetric(prefixesDesc, prometheus.GaugeValue, float64(n.PrefixSent), peerLabel, vrf)

--- a/frr-tools/metrics/collector/bgp_test.go
+++ b/frr-tools/metrics/collector/bgp_test.go
@@ -76,7 +76,7 @@ var (
 		{
 			desc:                 "Output contains only IPv4 advertisements",
 			vtyshOutput:          neighborsIPv4Only,
-			neighborIP:           "172.18.0.4:179",
+			neighborIP:           "172.18.0.4",
 			neighborVRF:          "default",
 			announcedPrefixes:    3,
 			receivedPrefixes:     3,
@@ -95,7 +95,7 @@ var (
 		{
 			desc:                 "Output contains mixed IPv4 and IPv6 advertisements",
 			vtyshOutput:          neighborsDual,
-			neighborIP:           "172.18.0.4:180",
+			neighborIP:           "172.18.0.4",
 			neighborVRF:          "default",
 			announcedPrefixes:    6,
 			receivedPrefixes:     6,


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:


> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

For each VRF we can have only one neighbor for a given address, which makes the port irrelevant.

Additionally, now that frr-k8s can accept connections too, the port can either be the one used on our side to establish the connection, or the source port in case we are accepting a bgp connection. This makes the metric labels non predictable and hard to monitor.

Because of this, here we remove the port from the label.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
The BGP metrics label corresponding to the peer does not have the port anymore. Because now FRR-K8S allow incoming connections, the port might be source port of the tcp connection, making the metrics label not reliable. Additionally, we can only have one peer per VRF, so the port is not relevant. 
```
