### PR TITLE
E2E: slim the graceful restart test

### DIFF
--- a/e2etests/pkg/config/from_containers.go
+++ b/e2etests/pkg/config/from_containers.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"fmt"
 	"net"
 
 	frrk8sv1beta1 "github.com/metallb/frr-k8s/api/v1beta1"
@@ -135,4 +136,13 @@ func ContainersForVRF(frrs []*frrcontainer.FRR, vrf string) []*frrcontainer.FRR 
 		}
 	}
 	return res
+}
+
+func ContainerByName(frrs []*frrcontainer.FRR, name string) (*frrcontainer.FRR, error) {
+	for _, f := range frrs {
+		if f.Name == name {
+			return f, nil
+		}
+	}
+	return nil, fmt.Errorf("container with name %s not found", name)
 }

--- a/e2etests/pkg/routes/routes.go
+++ b/e2etests/pkg/routes/routes.go
@@ -32,23 +32,23 @@ func PodHasPrefixFromContainer(pod *v1.Pod, frr frrcontainer.FRR, vrf, prefix st
 func CheckNeighborHasPrefix(neighbor frrcontainer.FRR, vrf, prefix string, nodes []v1.Node) error {
 	routesV4, routesV6, err := frr.Routes(neighbor)
 	if err != nil {
-		return err
+		return fmt.Errorf("Routes %w", err)
 	}
 
 	_, cidr, err := net.ParseCIDR(prefix)
 	if err != nil {
-		return err
+		return fmt.Errorf("ParseCIDR %w", err)
 	}
 
 	route, err := routeForCIDR(cidr, routesV4, routesV6)
 	if err != nil {
-		return err
+		return fmt.Errorf("routerForCIDR: %w", err)
 	}
 
 	cidrFamily := ipfamily.ForCIDR(cidr)
 	err = frr.RoutesMatchNodes(nodes, route, cidrFamily, vrf)
 	if err != nil {
-		return err
+		return fmt.Errorf("RoutesMatchNodes %w", err)
 	}
 	return nil
 }
@@ -62,7 +62,7 @@ type RouteNotFoundError struct {
 }
 
 func (e RouteNotFoundError) Error() string {
-	return fmt.Sprintf("route not found %s", e.Route)
+	return fmt.Sprintf("route not found for dst prefix %s", e.Route)
 }
 
 func routeForCIDR(cidr *net.IPNet, routesV4 map[string]frr.Route, routesV6 map[string]frr.Route) (frr.Route, error) {


### PR DESCRIPTION

This e2e test flakes often, and especially when the github actions
are slow. Therefore we reduce the overall peering to make the test
require less resources. What this commit does:
1. GR test will only use peering from single node to ebgp-single-hop
(so we will run 4x less `docker exec` to grab the routes).
2. GR test will restart single frr-k8s pod and will monitor that single
route and wait only that pod to be healthy.
3. Given we target the GR between specific host and specific peer, we
know which logs to look in case of failure.


 /kind flake


**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:

-->

```release-note
NONE
```
