### PR TITLE
Add route-map delay timer

### DIFF
--- a/internal/frr/templates/frr.tmpl
+++ b/internal/frr/templates/frr.tmpl
@@ -19,6 +19,8 @@ debug route-map detail
 hostname {{.Hostname}}
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
+
 
 {{- range $r := .Routers }}
 {{- range .Neighbors }}

--- a/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6.golden
+++ b/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6DisableMP.golden
+++ b/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6DisableMP.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestMultipleRoutersImportVRFs.golden
+++ b/internal/frr/testdata/TestMultipleRoutersImportVRFs.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 route-map 192.168.1.2-out permit 1

--- a/internal/frr/testdata/TestMultipleRoutersMultipleNeighs.golden
+++ b/internal/frr/testdata/TestMultipleRoutersMultipleNeighs.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestSingleSession
+++ b/internal/frr/testdata/TestSingleSession
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestSingleSession.golden
+++ b/internal/frr/testdata/TestSingleSession.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestSingleSessionBFD.golden
+++ b/internal/frr/testdata/TestSingleSessionBFD.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 route-map 192.168.1.2-out permit 1

--- a/internal/frr/testdata/TestSingleSessionWithAlwaysBlock.golden
+++ b/internal/frr/testdata/TestSingleSessionWithAlwaysBlock.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 route-map 192.168.1.2-out permit 1

--- a/internal/frr/testdata/TestSingleSessionWithEBGPMultihop.golden
+++ b/internal/frr/testdata/TestSingleSessionWithEBGPMultihop.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestSingleSessionWithEBGPMultihopAndExtras.golden
+++ b/internal/frr/testdata/TestSingleSessionWithEBGPMultihopAndExtras.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestSingleSessionWithExternalASN.golden
+++ b/internal/frr/testdata/TestSingleSessionWithExternalASN.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestSingleSessionWithGracefulRestart.golden
+++ b/internal/frr/testdata/TestSingleSessionWithGracefulRestart.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 route-map 192.168.1.2-out permit 1

--- a/internal/frr/testdata/TestSingleSessionWithIPv6SingleHop.golden
+++ b/internal/frr/testdata/TestSingleSessionWithIPv6SingleHop.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestSingleSessionWithInternalASN.golden
+++ b/internal/frr/testdata/TestSingleSessionWithInternalASN.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestTwoRoutersTwoNeighbors.golden
+++ b/internal/frr/testdata/TestTwoRoutersTwoNeighbors.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 

--- a/internal/frr/testdata/TestTwoRoutersTwoNeighborsBFD.golden
+++ b/internal/frr/testdata/TestTwoRoutersTwoNeighborsBFD.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 route-map 192.168.1.2-out permit 1

--- a/internal/frr/testdata/TestTwoSessionsAcceptAll.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptAll.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 route-map 192.168.1.2-out permit 1

--- a/internal/frr/testdata/TestTwoSessionsAcceptSomeV4.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptSomeV4.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 route-map 192.168.1.2-out permit 1

--- a/internal/frr/testdata/TestTwoSessionsAcceptV4AndV6.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptV4AndV6.golden
@@ -3,6 +3,7 @@ log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default
 ipv6 nht resolve-via-default
+bgp route-map delay-timer 20
 
 
 route-map 192.168.1.2-out permit 1


### PR DESCRIPTION
When the default value of 5 seconds is being used, Graceful-Restart can break momentarily on reconnect of BGP peering.

The restarter FRR when that timeout expires and the route-maps have not been processed, denies the routes, and therefore are removed.

```
DEBUG #bgpd[45]: Route-map: null, prefix: 99.0.0.0/24, result: deny
DEBUG #bgpd[45]: 10.0.64.1 [Update:SEND] 99.0.0.0/24 is filtered by route-map
```

https://github.com/FRRouting/frr/pull/10757
https://github.com/FRRouting/frr/issues/10756

/kind bug

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add route-map delay timer to avoid graceful restart breaking due to timing.
```
