### PR TITLE
Throw better error when prefix for same localPref is added twice

### DIFF
--- a/internal/controller/api_to_config_test.go
+++ b/internal/controller/api_to_config_test.go
@@ -844,6 +844,88 @@ func TestConversion(t *testing.T) {
 			err:      fmt.Errorf("multiple local prefs specified for prefix %s", "192.0.4.0/24"),
 		},
 		{
+			name: "One neighbor, trying to set samelocalPrefs for different prefix entries",
+			fromK8s: []v1beta1.FRRConfiguration{
+				{
+					Spec: v1beta1.FRRConfigurationSpec{
+						BGP: v1beta1.BGPConfig{
+							Routers: []v1beta1.Router{
+								{
+									ASN: 65040,
+									ID:  "192.0.2.20",
+									Neighbors: []v1beta1.Neighbor{
+										{
+											ASN:     65041,
+											Address: "192.0.2.21",
+											ToAdvertise: v1beta1.Advertise{
+												Allowed: v1beta1.AllowedOutPrefixes{
+													Prefixes: []string{"192.0.2.0/24", "10.0.0.0/24"},
+													Mode:     v1beta1.AllowRestricted,
+												},
+												PrefixesWithLocalPref: []v1beta1.LocalPrefPrefixes{
+													{
+														Prefixes:  []string{"10.0.0.0/24"},
+														LocalPref: 100,
+													},
+													{
+														Prefixes:  []string{"192.0.2.0/24"},
+														LocalPref: 100,
+													},
+												},
+											},
+										},
+									},
+									Prefixes: []string{"192.0.2.0/24", "10.0.0.0/24"},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets:  map[string]v1.Secret{},
+			expected: nil,
+			err:      fmt.Errorf("a not nil error"),
+		},
+		{
+			name: "One neighbor, trying to set samelocalPrefs for a prefix twice",
+			fromK8s: []v1beta1.FRRConfiguration{
+				{
+					Spec: v1beta1.FRRConfigurationSpec{
+						BGP: v1beta1.BGPConfig{
+							Routers: []v1beta1.Router{
+								{
+									ASN: 65040,
+									ID:  "192.0.2.20",
+									Neighbors: []v1beta1.Neighbor{
+										{
+											ASN:     65041,
+											Address: "192.0.2.21",
+											ToAdvertise: v1beta1.Advertise{
+												Allowed: v1beta1.AllowedOutPrefixes{
+													Prefixes: []string{"192.0.2.0/24", "192.0.2.0/24"},
+													Mode:     v1beta1.AllowRestricted,
+												},
+												PrefixesWithLocalPref: []v1beta1.LocalPrefPrefixes{
+													{
+														Prefixes:  []string{"192.0.2.0/24", "192.0.2.0/24"},
+														LocalPref: 100,
+													},
+												},
+											},
+										},
+									},
+									Prefixes: []string{"192.0.2.0/24"},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets:  map[string]v1.Secret{},
+			expected: nil,
+			err:      fmt.Errorf("a not nil error"),
+		},
+		{
 			name: "Neighbor with ToReceiveAll",
 			fromK8s: []v1beta1.FRRConfiguration{
 				{


### PR DESCRIPTION
Currently the return error for duplicate prefix
```
 withLocalPref:
  - prefixes:
      - "4.4.4.100/32"
      - "4.4.4.100/32"
    localPref: 100
```
is `multiple local prefs specified for prefix 4.4.4.100/32` which is misleading.

**Is this a BUG FIX or a FEATURE ?**:

/kind bug


**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
bug: throw better error when prefix for same localPref is added twice
```
