### PR TITLE
Use metrics for readiness/liveness probes

### DIFF
--- a/charts/frr-k8s/README.md
+++ b/charts/frr-k8s/README.md
@@ -35,7 +35,6 @@ Kubernetes: `>= 1.19.0-0`
 | frrk8s.frr.resources | object | `{}` |  |
 | frrk8s.frr.secureMetricsPort | int | `9141` |  |
 | frrk8s.frrMetrics.resources | object | `{}` |  |
-| frrk8s.healthPort | int | `8081` |  |
 | frrk8s.image.pullPolicy | string | `nil` |  |
 | frrk8s.image.repository | string | `"quay.io/metallb/frr-k8s"` |  |
 | frrk8s.image.tag | string | `nil` |  |

--- a/charts/frr-k8s/templates/controller.yaml
+++ b/charts/frr-k8s/templates/controller.yaml
@@ -199,7 +199,6 @@ spec:
         {{- with .Values.frrk8s.logLevel }}
         - --log-level={{ . }}
         {{- end }}
-        - --health-probe-bind-address={{.Values.prometheus.metricsBindAddress}}:{{ .Values.frrk8s.healthPort }}
         {{- if .Values.frrk8s.alwaysBlock }}
         - --always-block={{ .Values.frrk8s.alwaysBlock }}
         {{- end }}
@@ -222,8 +221,8 @@ spec:
         {{- if .Values.frrk8s.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: {{ .Values.frrk8s.healthPort }}
+            path: /metrics
+            port: monitoring
             host: {{ .Values.prometheus.metricsBindAddress }}
           initialDelaySeconds: {{ .Values.frrk8s.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frrk8s.livenessProbe.periodSeconds }}
@@ -234,8 +233,8 @@ spec:
         {{- if .Values.frrk8s.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /healthz
-            port: {{ .Values.frrk8s.healthPort }}
+            path: /metrics
+            port: monitoring
             host: {{ .Values.prometheus.metricsBindAddress }}
           initialDelaySeconds: {{ .Values.frrk8s.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frrk8s.readinessProbe.periodSeconds }}

--- a/charts/frr-k8s/templates/webhooks.yaml
+++ b/charts/frr-k8s/templates/webhooks.yaml
@@ -42,7 +42,7 @@ spec:
         - "--restart-on-rotator-secret-refresh=true"
         {{- end }}
         - "--namespace=$(NAMESPACE)"
-        - --health-probe-bind-address=:8081
+        - "--metrics-bind-address=:{{ .Values.prometheus.metricsPort }}"
         env:
         - name: NAMESPACE
           valueFrom:
@@ -59,11 +59,14 @@ spec:
             drop:
               - ALL
           readOnlyRootFilesystem: true
+        ports:
+        - containerPort: {{ .Values.prometheus.metricsPort }}
+          name: monitoring
         {{- if .Values.frrk8s.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: {{ .Values.frrk8s.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frrk8s.livenessProbe.periodSeconds }}
           failureThreshold: {{ .Values.frrk8s.livenessProbe.failureThreshold }}
@@ -71,8 +74,8 @@ spec:
         {{- if .Values.frrk8s.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /readyz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: {{ .Values.frrk8s.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frrk8s.readinessProbe.periodSeconds }}
           failureThreshold: {{ .Values.frrk8s.readinessProbe.failureThreshold }}

--- a/charts/frr-k8s/values.yaml
+++ b/charts/frr-k8s/values.yaml
@@ -128,7 +128,6 @@ frrk8s:
   podAnnotations: {}
   labels:
     app: frr-k8s
-  healthPort: 8081
   livenessProbe:
     enabled: true
     failureThreshold: 3

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -963,7 +963,7 @@ spec:
         - --log-level=info
         - --webhook-mode=onlywebhook
         - --namespace=$(NAMESPACE)
-        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:7572
         command:
         - /frr-k8s
         env:
@@ -975,15 +975,18 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 15
           periodSeconds: 20
         name: frr-k8s-webhook-server
+        ports:
+        - containerPort: 7572
+          name: monitoring
         readinessProbe:
           httpGet:
-            path: /readyz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
@@ -1107,7 +1110,6 @@ spec:
             drop:
             - ALL
       - args:
-        - --health-probe-bind-address=127.0.0.1:8081
         - --metrics-bind-address=127.0.0.1:7572
         - --node-name=$(NODE_NAME)
         - --namespace=$(NAMESPACE)
@@ -1132,8 +1134,8 @@ spec:
         livenessProbe:
           httpGet:
             host: 127.0.0.1
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 15
           periodSeconds: 20
         name: frr-k8s
@@ -1143,8 +1145,8 @@ spec:
         readinessProbe:
           httpGet:
             host: 127.0.0.1
-            path: /readyz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -932,7 +932,7 @@ spec:
         - --log-level=info
         - --webhook-mode=onlywebhook
         - --namespace=$(NAMESPACE)
-        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=:7572
         command:
         - /frr-k8s
         env:
@@ -944,15 +944,18 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 15
           periodSeconds: 20
         name: frr-k8s-webhook-server
+        ports:
+        - containerPort: 7572
+          name: monitoring
         readinessProbe:
           httpGet:
-            path: /readyz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:
@@ -1076,7 +1079,6 @@ spec:
             drop:
             - ALL
       - args:
-        - --health-probe-bind-address=127.0.0.1:8081
         - --metrics-bind-address=127.0.0.1:7572
         - --node-name=$(NODE_NAME)
         - --namespace=$(NAMESPACE)
@@ -1101,8 +1103,8 @@ spec:
         livenessProbe:
           httpGet:
             host: 127.0.0.1
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 15
           periodSeconds: 20
         name: frr-k8s
@@ -1112,8 +1114,8 @@ spec:
         readinessProbe:
           httpGet:
             host: 127.0.0.1
-            path: /readyz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/config/default/frr-k8s_auth_proxy_patch.yaml
+++ b/config/default/frr-k8s_auth_proxy_patch.yaml
@@ -73,7 +73,6 @@ spec:
             - ALL
       - name: frr-k8s
         args:
-        - "--health-probe-bind-address=127.0.0.1:8081"
         - "--metrics-bind-address=127.0.0.1:7572"
         - "--node-name=$(NODE_NAME)"
         - "--namespace=$(NAMESPACE)"

--- a/config/frr-k8s/frr-k8s.yaml
+++ b/config/frr-k8s/frr-k8s.yaml
@@ -57,15 +57,15 @@ spec:
           readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
             host: 127.0.0.1
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
-            path: /readyz
-            port: 8081
+            path: /metrics
+            port: monitoring
             host: 127.0.0.1
           initialDelaySeconds: 5
           periodSeconds: 10
@@ -243,7 +243,7 @@ spec:
         - "--log-level=info"
         - "--webhook-mode=onlywebhook"
         - "--namespace=$(NAMESPACE)"
-        - "--health-probe-bind-address=:8081"
+        - "--metrics-bind-address=:7572"
         env:
         - name: NAMESPACE
           valueFrom:
@@ -258,16 +258,19 @@ spec:
             drop:
               - ALL
           readOnlyRootFilesystem: true
+        ports:
+        - containerPort: 7572
+          name: monitoring
         livenessProbe:
           httpGet:
-            path: /healthz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
-            path: /readyz
-            port: 8081
+            path: /metrics
+            port: monitoring
           initialDelaySeconds: 5
           periodSeconds: 10
         # TODO(user): Configure the resources accordingly based on the project requirements.


### PR DESCRIPTION
Since the existing healthz/readyz don't do much, we leverage the metrics endpoints for readiness/liveness to avoid opening another port (8081) on the host.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:
/kind cleanup


**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
