### PR TITLE
E2E: repeat session open many times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ $(APIDOCSGEN): $(LOCALBIN)
 
 .PHONY: e2etests
 e2etests: ginkgo kubectl
-	$(GINKGO) -v $(GINKGO_ARGS) --timeout=3h ./e2etests -- --kubectl=$(KUBECTL) $(TEST_ARGS)
+	$(GINKGO) -v $(GINKGO_ARGS) --repeat=20 --timeout=3h ./e2etests -- --kubectl=$(KUBECTL) $(TEST_ARGS)
 
 
 .PHONY: kind-cluster

--- a/e2etests/tests/session.go
+++ b/e2etests/tests/session.go
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe("Session", func() {
 			ginkgo.Entry("IPV6", ipfamily.IPv6),
 		)
 
-		ginkgo.DescribeTable("Establishes sessions with graceful restart", func(family ipfamily.Family) {
+		ginkgo.FDescribeTable("Establishes sessions with graceful restart", func(family ipfamily.Family) {
 			frrs := config.ContainersForVRF(infra.FRRContainers, "")
 			neighbors := []frrk8sv1beta1.Neighbor{}
 


### PR DESCRIPTION


**Is this a BUG FIX or a FEATURE ?**:

/kind bug

> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

In frr-k8s backend (default) we allow the BGP peering to be opened by the peer.
This was not the case with the old backend. I observed that when the external peer is open the connection the BGP peering does not seem to get always the graceful restart capability.

from logs it simply looks the moment the BGP peering is established, the GR config is not place
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
