### PR TITLE
Add zebra -K argument and extend e2e testing

### DIFF
--- a/charts/frr-k8s/templates/controller.yaml
+++ b/charts/frr-k8s/templates/controller.yaml
@@ -49,7 +49,7 @@ data:
     # Check /etc/pam.d/frr if you intend to use "vtysh"!
     #
     vtysh_enable=yes
-    zebra_options="  -A 127.0.0.1 -s 90000000"
+    zebra_options="  -A 127.0.0.1 -K 120 -s 90000000"
     bgpd_options="   -A 127.0.0.1 {{ if not .Values.frrk8s.frr.acceptIncomingBGPConnections }} -p 0 {{- end }}"
     ospfd_options="  -A 127.0.0.1"
     ospf6d_options=" -A ::1"

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -841,7 +841,7 @@ data:
     # Check /etc/pam.d/frr if you intend to use "vtysh"!
     #
     vtysh_enable=yes
-    zebra_options="  -A 127.0.0.1 -s 90000000"
+    zebra_options="  -A 127.0.0.1 -K 120 -s 90000000"
     bgpd_options="   -A 127.0.0.1 -p 0"
     ospfd_options="  -A 127.0.0.1"
     ospf6d_options=" -A ::1"

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -810,7 +810,7 @@ data:
     # Check /etc/pam.d/frr if you intend to use "vtysh"!
     #
     vtysh_enable=yes
-    zebra_options="  -A 127.0.0.1 -s 90000000"
+    zebra_options="  -A 127.0.0.1 -K 120 -s 90000000"
     bgpd_options="   -A 127.0.0.1 -p 0"
     ospfd_options="  -A 127.0.0.1"
     ospf6d_options=" -A ::1"

--- a/config/frr-k8s/frr-cm.yaml
+++ b/config/frr-k8s/frr-cm.yaml
@@ -45,7 +45,7 @@ data:
     # Check /etc/pam.d/frr if you intend to use "vtysh"!
     #
     vtysh_enable=yes
-    zebra_options="  -A 127.0.0.1 -s 90000000"
+    zebra_options="  -A 127.0.0.1 -K 120 -s 90000000"
     bgpd_options="   -A 127.0.0.1 -p 0"
     ospfd_options="  -A 127.0.0.1"
     ospf6d_options=" -A ::1"

--- a/e2etests/go.mod
+++ b/e2etests/go.mod
@@ -6,13 +6,13 @@ toolchain go1.22.4
 
 replace (
 	github.com/metallb/frr-k8s => ../
-	go.universe.tf/e2etest => github.com/metallb/metallb/e2etest v0.0.0-20241212081358-ee34c275145f
+	go.universe.tf/e2etest => github.com/metallb/metallb/e2etest v0.0.0-20250127152015-3f9e99adbb0e
 	go.universe.tf/metallb => github.com/metallb/metallb v0.14.5
 )
 
 require (
 	github.com/google/go-cmp v0.6.0
-	github.com/metallb/frr-k8s v0.0.16
+	github.com/metallb/frr-k8s v0.0.17
 	github.com/onsi/ginkgo/v2 v2.19.0
 	github.com/onsi/gomega v1.33.1
 	github.com/openshift-kni/k8sreporter v1.0.4

--- a/e2etests/go.sum
+++ b/e2etests/go.sum
@@ -118,8 +118,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/metallb/metallb v0.14.5 h1:2KHXaqoHWh924YTb5aJ9VRahXtO+V2DxvVrH5WQgsHI=
 github.com/metallb/metallb v0.14.5/go.mod h1:ZraHgX0iQnmWMK9CBpgs/5zXV0SkGjiXpPOxHKNO/9s=
-github.com/metallb/metallb/e2etest v0.0.0-20241212081358-ee34c275145f h1:mj1tlV5E1W7B7RZ2ZJKEzijcNIYhQQrwXdvixs694FI=
-github.com/metallb/metallb/e2etest v0.0.0-20241212081358-ee34c275145f/go.mod h1:IhiGMcXxWTzsB2uxlTY60EWA922dqCBz69ncXjedA+c=
+github.com/metallb/metallb/e2etest v0.0.0-20250127152015-3f9e99adbb0e h1:JkwM2+RAbO+5yGlurRipSUAJedTUkX8pn7TwMlA1Esg=
+github.com/metallb/metallb/e2etest v0.0.0-20250127152015-3f9e99adbb0e/go.mod h1:EypEwGSpHBaI4fvPN03BaZRiu2bR06c10nZaFK1nwt8=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/moby/spdystream v0.4.0 h1:Vy79D6mHeJJjiPdFEL2yku1kl0chZpJfZcPpb16BRl8=

--- a/e2etests/go.work.sum
+++ b/e2etests/go.work.sum
@@ -208,6 +208,7 @@ github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118/go.mod h1:ZFUnHI
 github.com/mdlayher/ndp v0.0.0-20200602162440-17ab9e3e5567/go.mod h1:32w/5dDZWVSEOxyniAgKK4d7dHTuO6TCxWmUznQe3f8=
 github.com/mdlayher/packet v1.0.0/go.mod h1:eE7/ctqDhoiRhQ44ko5JZU2zxB88g+JH/6jmnjzPjOU=
 github.com/mdlayher/socket v0.2.1/go.mod h1:QLlNPkFR88mRUNQIzRBMfXxwKal8H7u1h3bL1CV+f0E=
+github.com/metallb/metallb/e2etest v0.0.0-20250127152015-3f9e99adbb0e/go.mod h1:EypEwGSpHBaI4fvPN03BaZRiu2bR06c10nZaFK1nwt8=
 github.com/miekg/dns v1.1.43/go.mod h1:+evo5L0630/F6ca/Z9+GAqzhjGyn8/c+TBaOyfEl0V4=
 github.com/mikioh/ipaddr v0.0.0-20190404000644-d465c8ab6721/go.mod h1:Ickgr2WtCLZ2MDGd4Gr0geeCH5HybhRJbonOgQpvSxc=
 github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=

--- a/e2etests/pkg/config/from_containers.go
+++ b/e2etests/pkg/config/from_containers.go
@@ -103,6 +103,17 @@ func EnableGracefulRestart(pc *PeersConfig) {
 	}
 }
 
+func EnableReceiveAllowAll(pc *PeersConfig) {
+	t := pc.PeersV4
+	for i := 0; i < len(t); i++ {
+		t[i].Neigh.ToReceive.Allowed.Mode = frrk8sv1beta1.AllowAll
+	}
+	t = pc.PeersV6
+	for i := 0; i < len(t); i++ {
+		t[i].Neigh.ToReceive.Allowed.Mode = frrk8sv1beta1.AllowAll
+	}
+}
+
 func EnableAllowAll(pc *PeersConfig) {
 	t := pc.PeersV4
 	for i := 0; i < len(t); i++ {


### PR DESCRIPTION
/kind bug


**What this PR does / why we need it**:
If we use learning routes, when we restart the pod those routes are gone from the k8s node. There is an option for zebra to keep them. That is useful only if Graceful restart is being used.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Add by default the -K (graceful_restart) argument in Zebra so that learnt routes are maintained on the host when zebra process restart.
```
