### PR TITLE
E2E: do not assert on the R-bit for sessions with Graceful Restart

### DIFF
--- a/e2etests/tests/session.go
+++ b/e2etests/tests/session.go
@@ -257,7 +257,6 @@ var _ = ginkgo.Describe("Session", func() {
 					Expect(n.GRInfo.LocalGrMode).Should(Equal("Restart"))
 					Expect(n.GRInfo.RemoteGrMode).Should(Equal("Helper"))
 					Expect(n.GRInfo.NBit).To(BeTrue())
-					Expect(n.GRInfo.RBit).To(BeTrue())
 				}
 			}
 		},


### PR DESCRIPTION
The R-bit might false depend on the FRR version and we do not control the value. So we avoid that check as it does not really add value.

From https://datatracker.ietf.org/doc/html/rfc4724

Restart Flags:

  This field contains bit flags related to restart.

      0 1 2 3
    +-+-+-+-+
    |R|Resv.|
    +-+-+-+-+

  The most significant bit is defined as the Restart State (R)
  bit, which can be used to avoid possible deadlock caused by
  waiting for the End-of-RIB marker when multiple BGP speakers
  peering with each other restart.  When set (value 1), this bit
  indicates that the BGP speaker has restarted, and its peer MUST
  NOT wait for the End-of-RIB marker from the speaker before
  advertising routing information to the speaker.

  The remaining bits are reserved and MUST be set to zero by the
  sender and ignored by the receiver.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
 /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
