### PR TITLE
Webhook pod: report ready / live when the webhook endpoint is ready

### DIFF
--- a/charts/frr-k8s/README.md
+++ b/charts/frr-k8s/README.md
@@ -71,6 +71,7 @@ Kubernetes: `>= 1.19.0-0`
 | frrk8s.tolerateMaster | bool | `true` |  |
 | frrk8s.tolerations | list | `[]` |  |
 | frrk8s.updateStrategy.type | string | `"RollingUpdate"` |  |
+| frrk8s.webhookPort | int | `9443` |  |
 | fullnameOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
 | prometheus.metricsBindAddress | string | `"127.0.0.1"` |  |

--- a/charts/frr-k8s/templates/webhooks.yaml
+++ b/charts/frr-k8s/templates/webhooks.yaml
@@ -31,6 +31,7 @@ spec:
       - command:
         - /frr-k8s
         args:
+        - --webhook-port={{ .Values.frrk8s.webhookPort }}
         {{- with .Values.frrk8s.logLevel }}
         - --log-level={{ . }}
         {{- end }}
@@ -60,13 +61,16 @@ spec:
               - ALL
           readOnlyRootFilesystem: true
         ports:
+        - containerPort: {{ .Values.frrk8s.webhookPort }}
+          name: webhook
         - containerPort: {{ .Values.prometheus.metricsPort }}
           name: monitoring
         {{- if .Values.frrk8s.livenessProbe.enabled }}
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: {{ .Values.frrk8s.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frrk8s.livenessProbe.periodSeconds }}
           failureThreshold: {{ .Values.frrk8s.livenessProbe.failureThreshold }}
@@ -74,8 +78,9 @@ spec:
         {{- if .Values.frrk8s.readinessProbe.enabled }}
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: {{ .Values.frrk8s.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.frrk8s.readinessProbe.periodSeconds }}
           failureThreshold: {{ .Values.frrk8s.readinessProbe.failureThreshold }}
@@ -131,7 +136,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 9443
+    targetPort: webhook
   selector:
     app.kubernetes.io/component: frr-k8s-webhook-server
 ---

--- a/charts/frr-k8s/values.yaml
+++ b/charts/frr-k8s/values.yaml
@@ -128,6 +128,7 @@ frrk8s:
   podAnnotations: {}
   labels:
     app: frr-k8s
+  webhookPort: 9443
   livenessProbe:
     enabled: true
     failureThreshold: 3

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,6 +79,7 @@ func main() {
 		webhookMode                   string
 		pprofAddr                     string
 		alwaysBlockCIDRs              string
+		webhookPort                   int
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "127.0.0.1:7572", "The address the metric endpoint binds to.")
@@ -92,6 +93,7 @@ func main() {
 	flag.StringVar(&certServiceName, "cert-service-name", "frr-k8s-webhook-service", "The service name used to generate the TLS cert's hostname")
 	flag.StringVar(&pprofAddr, "pprof-bind-address", "", "The address the pprof endpoints bind to.")
 	flag.StringVar(&alwaysBlockCIDRs, "always-block", "", "a list of comma separated cidrs we need to always block")
+	flag.IntVar(&webhookPort, "webhook-port", 9443, "the port we listen the webhook calls on")
 
 	opts := zap.Options{
 		Development: true,
@@ -119,7 +121,7 @@ func main() {
 		},
 		WebhookServer: webhook.NewServer(
 			webhook.Options{
-				Port: 9443,
+				Port: webhookPort,
 			},
 		),
 		Metrics: metricsserver.Options{

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -1040,7 +1040,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 9443
+    targetPort: webhook
   selector:
     control-plane: webhook-server
 ---
@@ -1086,18 +1086,22 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 20
         name: frr-k8s-webhook-server
         ports:
         - containerPort: 7572
           name: monitoring
+        - containerPort: 9443
+          name: webhook
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -1009,7 +1009,7 @@ metadata:
 spec:
   ports:
   - port: 443
-    targetPort: 9443
+    targetPort: webhook
   selector:
     control-plane: webhook-server
 ---
@@ -1055,18 +1055,22 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 20
         name: frr-k8s-webhook-server
         ports:
         - containerPort: 7572
           name: monitoring
+        - containerPort: 9443
+          name: webhook
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
         resources:

--- a/config/frr-k8s/frr-k8s.yaml
+++ b/config/frr-k8s/frr-k8s.yaml
@@ -296,16 +296,20 @@ spec:
         ports:
         - containerPort: 7572
           name: monitoring
+        - containerPort: 9443
+          name: webhook
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: 15
           periodSeconds: 20
         readinessProbe:
           httpGet:
-            path: /metrics
-            port: monitoring
+            path: /healthz
+            port: webhook
+            scheme: HTTPS
           initialDelaySeconds: 5
           periodSeconds: 10
         # TODO(user): Configure the resources accordingly based on the project requirements.

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 9443
+      targetPort: webhook
   selector:
     control-plane: webhook-server


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:

 /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

Instead of relying on the metrics port, we move to test the webhook endpoint. The webhook will declare itself ready only when the cert controller did its part and the certificate is generated correctly.

This allows the crs not to fail on creation if we apply them after checking all pods are ready (ie right after a make deploy).

Also, make the webhook port configurable.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Declare the webhook pod to be ready only when it can serve requests, checking the webhook endpoint as readiness probe.
```
