### PR TITLE
FRR: log stdout instead of a log file

### DIFF
--- a/charts/frr-k8s/templates/controller.yaml
+++ b/charts/frr-k8s/templates/controller.yaml
@@ -99,7 +99,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -285,20 +285,10 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
-        # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
-        # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
-        # This workaround is needed to have the frr logs as part of kubectl logs -c frr < controller_pod_name >.
         command:
           - /bin/sh
           - -c
-          - |
-            /sbin/tini -- /usr/lib/frr/docker-start &
-            attempts=0
-            until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-              sleep 1
-              attempts=$(( $attempts + 1 ))
-            done
-            tail -f /etc/frr/frr.log
+          - /sbin/tini -- /usr/lib/frr/docker-start
         {{- with .Values.frrk8s.frr.resources }}
         resources:
           {{- toYaml . | nindent 12 }}

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -1002,7 +1002,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
   vtysh.conf: |
     service integrated-vtysh-config
 kind: ConfigMap
@@ -1289,14 +1289,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - |
-          /sbin/tini -- /usr/lib/frr/docker-start &
-          attempts=0
-          until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-            sleep 1
-            attempts=$(( $attempts + 1 ))
-          done
-          tail -f /etc/frr/frr.log
+        - /sbin/tini -- /usr/lib/frr/docker-start
         env:
         - name: TINI_SUBREAPER
           value: "true"

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -971,7 +971,7 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational
   vtysh.conf: |
     service integrated-vtysh-config
 kind: ConfigMap
@@ -1258,14 +1258,7 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - |
-          /sbin/tini -- /usr/lib/frr/docker-start &
-          attempts=0
-          until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-            sleep 1
-            attempts=$(( $attempts + 1 ))
-          done
-          tail -f /etc/frr/frr.log
+        - /sbin/tini -- /usr/lib/frr/docker-start
         env:
         - name: TINI_SUBREAPER
           value: "true"

--- a/config/frr-k8s/frr-cm.yaml
+++ b/config/frr-k8s/frr-cm.yaml
@@ -95,4 +95,4 @@ data:
     frr defaults traditional
     hostname Router
     line vty
-    log file /etc/frr/frr.log informational
+    log stdout informational

--- a/config/frr-k8s/frr-k8s.yaml
+++ b/config/frr-k8s/frr-k8s.yaml
@@ -107,20 +107,10 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
-        # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
-        # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
-        # This workaround is needed to have the frr logs as part of kubectl logs -c frr < k8s-frr-podname >.
         command:
           - /bin/sh
           - -c
-          - |
-            /sbin/tini -- /usr/lib/frr/docker-start &
-            attempts=0
-            until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
-              sleep 1
-              attempts=$(( $attempts + 1 ))
-            done
-            tail -f /etc/frr/frr.log
+          - /sbin/tini -- /usr/lib/frr/docker-start
         livenessProbe:
           httpGet:
             path: /livez

--- a/e2etests/pkg/dump/frr.go
+++ b/e2etests/pkg/dump/frr.go
@@ -55,7 +55,7 @@ func BGPInfo(testName string, FRRContainers []*frrcontainer.FRR, cs clientset.In
 	Expect(err).NotTo(HaveOccurred())
 	for _, pod := range frrk8sPods {
 		podExec := executor.ForPod(pod.Namespace, pod.Name, "frr")
-		dump, err := frr.RawDump(podExec, "/etc/frr/frr.conf", "/etc/frr/frr.log")
+		dump, err := frr.RawDump(podExec, "/etc/frr/frr.conf")
 		if err != nil {
 			ginkgo.GinkgoWriter.Printf("External frr dump for pod %s failed %v", pod.Name, err)
 			continue

--- a/internal/frr/templates/frr.tmpl
+++ b/internal/frr/templates/frr.tmpl
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log {{.Loglevel}}
+log stdout {{.Loglevel}}
 log timestamp precision 3
 {{- if eq .Loglevel "debugging" }}
 debug zebra events

--- a/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6.golden
+++ b/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6DualStackIPFamily.golden
+++ b/internal/frr/testdata/TestMultipleNeighborsOneV4AndOneV6DualStackIPFamily.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestMultipleRoutersImportVRFs.golden
+++ b/internal/frr/testdata/TestMultipleRoutersImportVRFs.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestMultipleRoutersMultipleNeighs.golden
+++ b/internal/frr/testdata/TestMultipleRoutersMultipleNeighs.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSession
+++ b/internal/frr/testdata/TestSingleSession
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSession.golden
+++ b/internal/frr/testdata/TestSingleSession.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSessionBFD.golden
+++ b/internal/frr/testdata/TestSingleSessionBFD.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSessionWithAlwaysBlock.golden
+++ b/internal/frr/testdata/TestSingleSessionWithAlwaysBlock.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSessionWithEBGPMultihop.golden
+++ b/internal/frr/testdata/TestSingleSessionWithEBGPMultihop.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSessionWithEBGPMultihopAndExtras.golden
+++ b/internal/frr/testdata/TestSingleSessionWithEBGPMultihopAndExtras.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSessionWithExternalASN.golden
+++ b/internal/frr/testdata/TestSingleSessionWithExternalASN.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSessionWithGracefulRestart.golden
+++ b/internal/frr/testdata/TestSingleSessionWithGracefulRestart.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSessionWithIPv6SingleHop.golden
+++ b/internal/frr/testdata/TestSingleSessionWithIPv6SingleHop.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleSessionWithInternalASN.golden
+++ b/internal/frr/testdata/TestSingleSessionWithInternalASN.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestSingleUnnumberedSession.golden
+++ b/internal/frr/testdata/TestSingleUnnumberedSession.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestTwoRoutersTwoNeighbors.golden
+++ b/internal/frr/testdata/TestTwoRoutersTwoNeighbors.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestTwoRoutersTwoNeighborsBFD.golden
+++ b/internal/frr/testdata/TestTwoRoutersTwoNeighborsBFD.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestTwoSessionsAcceptAll.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptAll.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestTwoSessionsAcceptSomeV4.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptSomeV4.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default

--- a/internal/frr/testdata/TestTwoSessionsAcceptV4AndV6.golden
+++ b/internal/frr/testdata/TestTwoSessionsAcceptV4AndV6.golden
@@ -1,4 +1,4 @@
-log file /etc/frr/frr.log informational
+log stdout informational
 log timestamp precision 3
 hostname dummyhostname
 ip nht resolve-via-default


### PR DESCRIPTION
We remove the workaround which is no longer needed, with this we won't have the log file that grows infinitely without rotation.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
frr container: no longer contains a log file, logs are sent directly to stdout. this enables the logs to be rotated on the node.
```
