### PR TITLE
Webhook: improve performance on scale

### DIFF
--- a/internal/webhooks/frrconfiguration_webhook_benchmark_test.go
+++ b/internal/webhooks/frrconfiguration_webhook_benchmark_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package webhooks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/metallb/frr-k8s/api/v1beta1"
+	"github.com/metallb/frr-k8s/internal/controller"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func BenchmarkValidateConfig(b *testing.B) {
+	nodes := generateNodes(100)
+	configs := generateFRRConfigurations(nodes, 20)
+	originalGetNodes := getNodes
+	originalGetFRRConfigurations := getFRRConfigurations
+	originalValidate := Validate
+
+	defer func() {
+		getNodes = originalGetNodes
+		getFRRConfigurations = originalGetFRRConfigurations
+		Validate = originalValidate
+	}()
+
+	getNodes = func() ([]corev1.Node, error) {
+		return nodes, nil
+	}
+
+	getFRRConfigurations = func() (*v1beta1.FRRConfigurationList, error) {
+		return &v1beta1.FRRConfigurationList{Items: configs}, nil
+	}
+
+	Validate = controller.Validate
+
+	testConfig := &v1beta1.FRRConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "default",
+		},
+		Spec: v1beta1.FRRConfigurationSpec{
+			NodeSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"node-id": "node-0",
+				},
+			},
+			BGP: v1beta1.BGPConfig{
+				Routers: []v1beta1.Router{
+					{
+						ASN: 65001,
+						ID:  "192.168.1.1",
+						VRF: "",
+						Neighbors: []v1beta1.Neighbor{
+							{
+								ASN:     65002,
+								Address: "192.168.1.2",
+								Port:    ptr.To[uint16](179),
+							},
+						},
+						Prefixes: []string{"192.168.1.0/24"},
+					},
+				},
+			},
+		},
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		_, err := validateConfig(testConfig)
+		if err != nil {
+			b.Fatalf("validation failed: %v", err)
+		}
+	}
+}
+
+func generateNodes(count int) []corev1.Node {
+	nodes := make([]corev1.Node, count)
+	for i := range count {
+		nodes[i] = corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("node-%d", i),
+				Labels: map[string]string{
+					"node-id": fmt.Sprintf("node-%d", i),
+				},
+			},
+		}
+	}
+	return nodes
+}
+
+func generateFRRConfigurations(nodes []corev1.Node, configsPerNode int) []v1beta1.FRRConfiguration {
+	totalConfigs := len(nodes) * configsPerNode
+	configs := make([]v1beta1.FRRConfiguration, totalConfigs)
+
+	configIndex := 0
+	for _, node := range nodes {
+		for range configsPerNode {
+			configs[configIndex] = v1beta1.FRRConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("frr-config-%d", configIndex),
+					Namespace: "default",
+				},
+				Spec: v1beta1.FRRConfigurationSpec{
+					NodeSelector: metav1.LabelSelector{
+						MatchLabels: node.Labels,
+					},
+					BGP: v1beta1.BGPConfig{
+						Routers: []v1beta1.Router{
+							{
+								ASN: 65001,
+								ID:  "192.168.1.1",
+								VRF: "",
+								Neighbors: []v1beta1.Neighbor{
+									{
+										ASN:     65002,
+										Address: "192.168.1.2",
+										Port:    ptr.To[uint16](179),
+									},
+								},
+								Prefixes: []string{"192.168.1.0/24"},
+							},
+						},
+					},
+				},
+			}
+			configIndex++
+		}
+	}
+	return configs
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

  metav1.LabelSelectorAsSelector is the biggest offender in terms of
  performances in the validation function. Here we add an lru cache so the
  result can be cached for reasonable numbers.
  
  Also, avoid deepcopy as it puts more stress on the GC.


Before

```
go test -bench=BenchmarkValidateConfig -benchmem -benchtime=10s -count=3
goos: linux
goarch: amd64
pkg: github.com/metallb/frr-k8s/internal/webhooks
cpu: Intel(R) Xeon(R) Gold 6230R CPU @ 2.10GHz
BenchmarkValidateConfig-104                 4042           2949891 ns/op          959868 B/op      23363 allocs/op
BenchmarkValidateConfig-104                 4044           2960876 ns/op          960273 B/op      23363 allocs/op
BenchmarkValidateConfig-104                 4033           2956161 ns/op          960348 B/op      23363 allocs/op
PASS
ok      github.com/metallb/frr-k8s/internal/webhooks    35.852s
```
After

```
go test -bench=BenchmarkValidateConfig -benchmem -benchtime=10s -count=3
goos: linux
goarch: amd64
pkg: github.com/metallb/frr-k8s/internal/webhooks
cpu: Intel(R) Xeon(R) Gold 6230R CPU @ 2.10GHz
BenchmarkValidateConfig-104                 7335           1621307 ns/op          275721 B/op       9227 allocs/op
BenchmarkValidateConfig-104                 7335           1624197 ns/op          275670 B/op       9227 allocs/op
BenchmarkValidateConfig-104                 7347           1625323 ns/op          275672 B/op       9227 allocs/op
```

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Webhook performance improvements on scale
```
