### PR TITLE
Fix frr-reloader error capture with --stdout flag

### DIFF
--- a/e2etests/pkg/k8s/frrk8s.go
+++ b/e2etests/pkg/k8s/frrk8s.go
@@ -5,9 +5,11 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 )
 
@@ -19,7 +21,26 @@ func FRRK8sDaemonSet(cs clientset.Interface) (*appsv1.DaemonSet, error) {
 		return nil, err
 	}
 	if len(daemonSets.Items) != 1 {
-		return nil, fmt.Errorf("Expected exactly one frr-k8s daemonset, got %d", len(daemonSets.Items))
+		return nil, fmt.Errorf("expected exactly one frr-k8s daemonset, got %d", len(daemonSets.Items))
 	}
-	return &daemonSets.Items[0], nil
+	frrK8sDaemonSet := &daemonSets.Items[0]
+
+	err = wait.PollUntilContextTimeout(context.Background(), 5*time.Second, 2*time.Minute, true,
+		func(ctx context.Context) (bool, error) {
+			ds, err := cs.AppsV1().DaemonSets(FRRK8sNamespace).Get(ctx, frrK8sDaemonSet.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			if ds.Status.NumberReady == ds.Status.DesiredNumberScheduled && ds.Status.NumberUnavailable == 0 {
+				frrK8sDaemonSet = ds
+				return true, nil
+			}
+			return false, nil
+		})
+
+	if err != nil {
+		return nil, fmt.Errorf("timed out waiting for frr-k8s daemonset to be ready: %w", err)
+	}
+	return frrK8sDaemonSet, nil
 }

--- a/e2etests/tests/status.go
+++ b/e2etests/tests/status.go
@@ -462,6 +462,10 @@ var _ = ginkgo.Describe("Exposing FRR status", func() {
 			delete(excludedNodePtr.Labels, "test-exclude")
 			_, err = cs.CoreV1().Nodes().Update(context.Background(), excludedNodePtr, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
+
+      ginkgo.By("Waiting that all pods of the daemonset running")
+			_, err = k8s.FRRK8sDaemonSet(cs)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/frr-tools/reloader/frr-reloader.sh
+++ b/frr-tools/reloader/frr-reloader.sh
@@ -17,7 +17,7 @@ reload_frr() {
   kill_sleep
 
   echo "Checking the configuration file syntax"
-  if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" >"$LAST_ERROR_FILE" 2>&1 | sed 's/password.*/password <retracted>/g'; then
+  if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" 2>"$LAST_ERROR_FILE" | sed 's/password.*/password <retracted>/g'; then
     echo "Syntax error spotted: aborting.. $SECONDS seconds"
     cat "$LAST_ERROR_FILE" | sed 's/password.*/password <retracted>/g'
     echo -n "$(date +%s) failure"  > "$STATUSFILE"

--- a/frr-tools/reloader/frr-reloader.sh
+++ b/frr-tools/reloader/frr-reloader.sh
@@ -17,7 +17,7 @@ reload_frr() {
   kill_sleep
 
   echo "Checking the configuration file syntax"
-  if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" 2>"$LAST_ERROR_FILE" | sed 's/password.*/password <retracted>/g'; then
+  if ! python3 /usr/lib/frr/frr-reload.py --test --stdout "$FILE_TO_RELOAD" >"$LAST_ERROR_FILE" 2>&1 | sed 's/password.*/password <retracted>/g'; then
     echo "Syntax error spotted: aborting.. $SECONDS seconds"
     cat "$LAST_ERROR_FILE" | sed 's/password.*/password <retracted>/g'
     echo -n "$(date +%s) failure"  > "$STATUSFILE"


### PR DESCRIPTION
FRR 10.4.1 changed frr-reload.py logging behavior: when using --stdout, errors now go to stdout instead of stderr. Changed redirection from 2>file to >file 2>&1 to capture all output in the error file while maintaining container log visibility.

https://github.com/FRRouting/frr/blob/master/tools/frr-reload.py

**Is this a BUG FIX or a FEATURE ?**:

/kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:
This is the breaking change before we move to 10.4 FRR release, if we can merge it earlier (which means works with 9.1 version) then the transition will be smoother

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
