### PR TITLE
fix: duplicate port name "monitoring"

### DIFF
--- a/charts/frr-k8s/templates/controller.yaml
+++ b/charts/frr-k8s/templates/controller.yaml
@@ -346,7 +346,7 @@ spec:
           - --metrics-bind-address={{ .Values.frrk8s.frr.metricsBindAddress }}
         ports:
           - containerPort: {{ .Values.frrk8s.frr.metricsPort }}
-            name: monitoring
+            name: frr-metrics
         volumeMounts:
           - name: frr-sockets
             mountPath: /var/run/frr

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -1389,7 +1389,7 @@ spec:
         name: frr-metrics
         ports:
         - containerPort: 7573
-          name: monitoring
+          name: frr-metrics
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -1358,7 +1358,7 @@ spec:
         name: frr-metrics
         ports:
         - containerPort: 7573
-          name: monitoring
+          name: frr-metrics
         volumeMounts:
         - mountPath: /var/run/frr
           name: frr-sockets

--- a/config/frr-k8s/frr-k8s.yaml
+++ b/config/frr-k8s/frr-k8s.yaml
@@ -144,7 +144,7 @@ spec:
           - --metrics-bind-address=127.0.0.1
         ports:
           - containerPort: 7573
-            name: monitoring
+            name: frr-metrics
         volumeMounts:
           - name: frr-sockets
             mountPath: /var/run/frr


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

**What this PR does / why we need it**:

Deploying the all-in-one YAML results in the following warning.

Warning: spec.template.spec.containers[4].ports[0]: duplicate port name "monitoring" with spec.template.spec.containers[2].ports[0], services and probes that select ports by name will use spec.template.spec.containers[2].ports[0]

This hopefully fixes that by renaming the frr-metrics port from monitoring to frr-metrics.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Fix duplicate port name `monitoring` when deploying the all-in-one.yaml
```
