### PR TITLE
Release notes: automate the generation

### DIFF
--- a/HOW_TO_RELEASE.md
+++ b/HOW_TO_RELEASE.md
@@ -23,17 +23,32 @@ git push
 
 ## Generate the release notes
 
-A convenience generator script is added under `website/gen_relnotes.sh`. The syntax is
-as follows:
+A convenience generator script is available at `hack/gen_relnotes.sh`. The script can be run in two modes:
+
+### Automatic mode (recommended)
 
 ```bash
-hack/gen_relnotes.sh <branch> <first commit> <last commit>
+hack/gen_relnotes.sh
 ```
 
-Where branch is the branch being released, first and last commit is the interval
-we want to generate the release notes for.
+This will automatically:
+- Find the previous release commit (searches for "Prepare the v*" commits)
+- Use the HEAD of `upstream/main` as the end point
+- Auto-increment the patch version from the current release
+- Generate categorized release notes based on PR labels (`kind/feature`, `kind/bug`, `kind/cleanup`)
+- Update `RELEASE_NOTES.md` with the new release section
 
-The `GITHUB_TOKEN` environment variable must be set with a github token which has the following permissions:
+### Manual mode with custom version
+
+```bash
+hack/gen_relnotes.sh 0.0.21
+```
+
+This will use the provided version number instead of auto-incrementing.
+
+### Prerequisites
+
+The `GITHUB_TOKEN` environment variable must be set with a GitHub token which has the following permissions:
 
 Read access to:
 
@@ -43,9 +58,13 @@ Read access to:
 
 ## Finalize the release notes
 
-All release notes are always written on the main branch in the `RELEASE_NOTES.md` file, and copied into release branches in a later step. Point out all new features and actions required by users. If there are very notable bugfixes (e.g. security issues, long-term pain point resolved), point those out as well.
+All release notes are always written on the main branch in the `RELEASE_NOTES.md` file, and copied into release branches in a later step.
 
-For each new release, a section like `## Release vX.Y.Z` must be added.
+After running the generation script, review the generated notes and:
+- Point out all new features and actions required by users
+- Highlight notable bugfixes (e.g. security issues, long-term pain points resolved)
+- Verify all PRs are properly categorized
+- Add any additional context or explanations as needed
 
 To get a list of contributors to the release, run `git log --format="%aN" $(git merge-base CUR-BRANCH PREV-TAG)..CUR-BRANCH | sort -u | tr '\n' ',' | sed -e 's/,/, /g'`. CUR-BRANCH is main if you’re making a minor release (e.g. 0.9.0), or the release branch for the current version if you’re making a patch release (e.g. v0.8 if you’re making v0.8.4). PREV-TAG is the release tag name for the last release (e.g. if you’re preparing 0.8.4, PREV-TAG is v0.8.3. Also think about whether there were significant contributions that weren’t in the form of a commit, and include those people as well. It’s better to err on the side of being too thankful!
 

--- a/hack/gen_relnotes.sh
+++ b/hack/gen_relnotes.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -e
-set -x
+
+# Script to automate generation and committing of release notes
+# Usage:
+#   ./hack/gen_relnotes.sh           # Automates entire release notes workflow (auto-increments version)
+#   ./hack/gen_relnotes.sh <version> # Automates workflow with custom version (e.g., 1.2.3)
+
+set -e
 
 if [[ ! -v GITHUB_TOKEN ]]; then
     echo "GITHUB_TOKEN is not set, please set it with a token with read permissions on commits and PRs"
@@ -7,26 +13,113 @@ if [[ ! -v GITHUB_TOKEN ]]; then
 fi
 
 script_dir=$(dirname "$(readlink -f "$0")")
+repo_root=$(cd "$script_dir/.." && pwd)
 
-branch=$1
-from=$2
-to=$3
+get_latest_version() {
+    grep -m 1 "^## Release v" "$repo_root/RELEASE_NOTES.md" | sed 's/## Release v//'
+}
+
+increment_version() {
+    local version=$1
+    # Split version into parts
+    local major=$(echo "$version" | cut -d. -f1)
+    local minor=$(echo "$version" | cut -d. -f2)
+    local patch=$(echo "$version" | cut -d. -f3)
+
+    # Increment patch version
+    patch=$((patch + 1))
+
+    echo "${major}.${minor}.${patch}"
+}
+
+if [ $# -eq 0 ] || [ $# -eq 1 ]; then
+    # Automated mode
+    echo "Running in automated mode..."
+
+    branch=${BRANCH:-main}
+
+    # Find the SHA of the most recent "Prepare the v*" commit
+    from=$(git log --all --grep="^Prepare the v" --format="%H" | head -1)
+
+    if [ -z "$from" ]; then
+        echo "Error: Could not find a previous 'Prepare the v*' commit"
+        echo "This might be the first release."
+        exit 1
+    fi
+
+    to=$(git rev-parse upstream/main)
+
+    current_version=$(get_latest_version)
+
+    if [ $# -eq 1 ]; then
+        new_version=$1
+        echo "Found previous release commit: $from"
+        echo "Current HEAD: $to"
+        echo "Current version: v$current_version"
+        echo "Using provided version: v$new_version"
+    else
+        new_version=$(increment_version "$current_version")
+        echo "Found previous release commit: $from"
+        echo "Current HEAD: $to"
+        echo "Current version: v$current_version"
+        echo "Auto-incrementing to version: v$new_version"
+    fi
+else
+    echo "Usage: $0 [version]"
+    echo "  No arguments: Automated mode (auto-increments patch version)"
+    echo "  1 argument: Automated mode with custom version (e.g., $0 1.2.3)"
+    exit 1
+fi
+
 release_notes=$(mktemp)
 
 end() {
-    rm $release_notes
+    rm -f "$release_notes"
 }
 
 trap end EXIT SIGINT SIGTERM SIGSTOP
 
+echo "Generating release notes..."
 GOFLAGS=-mod=mod go run k8s.io/release/cmd/release-notes@v0.16.5 \
-    --branch $branch \
+    --branch "$branch" \
     --required-author "" \
     --org metallb \
     --dependencies=false \
     --repo frr-k8s \
-    --start-sha $from \
-    --end-sha $to \
-    --output $release_notes
+    --start-sha "$from" \
+    --end-sha "$to" \
+    --go-template "go-template:$script_dir/release-notes-template.md" \
+    --output "$release_notes"
 
-cat $release_notes
+temp_notes=$(mktemp)
+
+echo "# FRRK8s Release Notes" > "$temp_notes"
+echo "" >> "$temp_notes"
+echo "## Release v$new_version" >> "$temp_notes"
+echo "" >> "$temp_notes"
+
+cat "$release_notes" >> "$temp_notes"
+echo "" >> "$temp_notes"
+echo "" >> "$temp_notes"
+
+tail -n +3 "$repo_root/RELEASE_NOTES.md" >> "$temp_notes"
+
+mv "$temp_notes" "$repo_root/RELEASE_NOTES.md"
+
+echo ""
+echo "Release notes have been updated in RELEASE_NOTES.md"
+echo ""
+
+echo "Changes to be committed:"
+git diff "$repo_root/RELEASE_NOTES.md"
+
+read -p "Do you want to commit these changes? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    git add "$repo_root/RELEASE_NOTES.md"
+    git commit -m "Prepare the v$new_version release notes"
+    echo ""
+    echo "Committed: Prepare the v$new_version release notes"
+else
+    echo "Commit cancelled. Changes are staged but not committed."
+fi

--- a/hack/release-notes-template.md
+++ b/hack/release-notes-template.md
@@ -1,0 +1,44 @@
+{{- $hasFeature := false -}}
+{{- $hasBug := false -}}
+{{- $hasCleanup := false -}}
+{{- range .Notes -}}
+  {{- if eq .Kind "feature" -}}{{- $hasFeature = true -}}{{- end -}}
+  {{- if eq .Kind "bug" -}}{{- $hasBug = true -}}{{- end -}}
+  {{- if eq .Kind "Other (Cleanup or Flake)" -}}{{- $hasCleanup = true -}}{{- end -}}
+{{- end }}
+{{- if $hasFeature }}
+
+### New Features
+
+{{- range .Notes }}
+{{- if eq .Kind "feature" }}
+{{- range .NoteEntries }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $hasBug }}
+
+### Bug fixes
+
+{{- range .Notes }}
+{{- if eq .Kind "bug" }}
+{{- range .NoteEntries }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $hasCleanup }}
+
+### Other (Cleanup or Flake)
+
+{{- range .Notes }}
+{{- if eq .Kind "Other (Cleanup or Flake)" }}
+{{- range .NoteEntries }}
+- {{.}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
/kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

The generation of the release notes was half baked, including a lot of manual steps.
Here we try to fully automate it by fetching the previous commit containing a release note and optinally committing it.

All the user needs to provide is the GITHUB_TOKEN env variable.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
