### PR TITLE
Add readOnlyRootFilesystem=true to containers missing it

### DIFF
--- a/charts/frr-k8s/templates/controller.yaml
+++ b/charts/frr-k8s/templates/controller.yaml
@@ -153,6 +153,10 @@ spec:
           emptyDir: {}
         - name: frr-status
           emptyDir: {}
+        - name: frr-lib
+          emptyDir: {}
+        - name: frr-tmp
+          emptyDir: {}
       {{- if .Values.prometheus.metricsTLSSecret }}
         - name: metrics-certs
           secret:
@@ -267,6 +271,8 @@ spec:
             mountPath: /etc/frr_reloader
       - name: frr
         securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             add:
             - NET_ADMIN
@@ -285,6 +291,10 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
+          - name: frr-lib
+            mountPath: /var/lib/frr
+          - name: frr-tmp
+            mountPath: /var/tmp/frr
         # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
         # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
         # This workaround is needed to have the frr logs as part of kubectl logs -c frr < controller_pod_name >.

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -1362,12 +1362,14 @@ spec:
           periodSeconds: 5
         name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
             - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 30
           httpGet:
@@ -1380,6 +1382,10 @@ spec:
           name: frr-sockets
         - mountPath: /etc/frr
           name: frr-conf
+        - mountPath: /var/lib/frr
+          name: frr-lib
+        - mountPath: /var/tmp/frr
+          name: frr-tmp
       - args:
         - --metrics-port=7573
         - --metrics-bind-address=127.0.0.1
@@ -1503,6 +1509,10 @@ spec:
         name: metrics
       - emptyDir: {}
         name: frr-status
+      - emptyDir: {}
+        name: frr-lib
+      - emptyDir: {}
+        name: frr-tmp
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -1331,12 +1331,14 @@ spec:
           periodSeconds: 5
         name: frr
         securityContext:
+          allowPrivilegeEscalation: false
           capabilities:
             add:
             - NET_ADMIN
             - NET_RAW
             - SYS_ADMIN
             - NET_BIND_SERVICE
+          readOnlyRootFilesystem: true
         startupProbe:
           failureThreshold: 30
           httpGet:
@@ -1349,6 +1351,10 @@ spec:
           name: frr-sockets
         - mountPath: /etc/frr
           name: frr-conf
+        - mountPath: /var/lib/frr
+          name: frr-lib
+        - mountPath: /var/tmp/frr
+          name: frr-tmp
       - args:
         - --metrics-port=7573
         - --metrics-bind-address=127.0.0.1
@@ -1472,6 +1478,10 @@ spec:
         name: metrics
       - emptyDir: {}
         name: frr-status
+      - emptyDir: {}
+        name: frr-lib
+      - emptyDir: {}
+        name: frr-tmp
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/config/frr-k8s/frr-k8s.yaml
+++ b/config/frr-k8s/frr-k8s.yaml
@@ -97,6 +97,8 @@ spec:
               fieldPath: metadata.namespace
       - name: frr
         securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
           capabilities:
             add: ["NET_ADMIN", "NET_RAW", "SYS_ADMIN", "NET_BIND_SERVICE"]
         image: quay.io/frrouting/frr:10.4.1
@@ -108,6 +110,10 @@ spec:
             mountPath: /var/run/frr
           - name: frr-conf
             mountPath: /etc/frr
+          - name: frr-lib
+            mountPath: /var/lib/frr
+          - name: frr-tmp
+            mountPath: /var/tmp/frr
         # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
         # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
         # This workaround is needed to have the frr logs as part of kubectl logs -c frr < k8s-frr-podname >.
@@ -209,6 +215,10 @@ spec:
         - name: metrics
           emptyDir: {}
         - name: frr-status
+          emptyDir: {}
+        - name: frr-lib
+          emptyDir: {}
+        - name: frr-tmp
           emptyDir: {}
       initContainers:
         # Copies the initial config files with the right permissions to the shared volume.


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:
/kind bug

**What this PR does / why we need it**:
`readOnlyRootFilesystem` prevents containers from writing to the root filesystem, reducing attack surface and improving security posture by limiting potential malicious file modifications and ensuring immutable container runtime.

`allowPrivilegeEscalation=false` prevents containers from gaining additional privileges beyond those initially granted, further hardening the security posture by blocking privilege escalation attacks.


```release-note
Added `readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false` to containers missing these security flags, enhancing container security posture without affecting functionality.
```
