### PR TITLE
Make it more explicit that rawConfig is unsupported

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -380,6 +380,11 @@ RawConfig is a snippet of raw frr configuration that gets appended to the
 rendered configuration.
 
 
+WARNING: The RawConfig feature is UNSUPPORTED and intended ONLY FOR EXPERIMENTATION.
+It should not be used in production environments. This feature is provided as-is without any
+guarantees of stability, compatibility, or support. Use at your own risk.
+
+
 
 _Appears in:_
 - [FRRConfigurationSpec](#frrconfigurationspec)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ spec:
 
 ### Adding a raw configuration
 
+> **WARNING**: The `rawConfig` feature is **UNSUPPORTED** and intended **ONLY FOR EXPERIMENTATION**.
+> It should not be used in production environments. This feature is provided as-is without any
+> guarantees of stability, compatibility, or support. Use at your own risk.
+
 In order to facilitate experimentation and to fill gaps quickly, it is possible to set a piece of raw
 FRR configuration that is appended to the rendered one. In order to do so, the `rawConfig` field
 must be set:

--- a/api/v1beta1/frrconfiguration_types.go
+++ b/api/v1beta1/frrconfiguration_types.go
@@ -40,6 +40,10 @@ type FRRConfigurationSpec struct {
 
 // RawConfig is a snippet of raw frr configuration that gets appended to the
 // rendered configuration.
+//
+// WARNING: The RawConfig feature is UNSUPPORTED and intended ONLY FOR EXPERIMENTATION.
+// It should not be used in production environments. This feature is provided as-is without any
+// guarantees of stability, compatibility, or support. Use at your own risk.
 type RawConfig struct {
 	// Priority is the order with this configuration is appended to the
 	// bottom of the rendered configuration. A higher value means the


### PR DESCRIPTION


<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
/kind documentation
> /kind regression

**What this PR does / why we need it**:

The README file already says that the field is to be used for experimentation only, but we want to clarify that no support is guaranteed for the field.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
