### PR TITLE
Clarify DisableMP field documentation to indicate it's ignored

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -350,7 +350,7 @@ _Appears in:_
 | `enableGracefulRestart` _boolean_ | EnableGracefulRestart allows BGP peer to continue to forward data packets along<br />known routes while the routing protocol information is being restored. If<br />the session is already established, the configuration will have effect<br />after reconnecting to the peer |  |  |
 | `toAdvertise` _[Advertise](#advertise)_ | ToAdvertise represents the list of prefixes to advertise to the given neighbor<br />and the associated properties. |  |  |
 | `toReceive` _[Receive](#receive)_ | ToReceive represents the list of prefixes to receive from the given neighbor. |  |  |
-| `disableMP` _boolean_ | To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.<br /><br />Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily. | false |  |
+| `disableMP` _boolean_ | DisableMP is no longer used and has no effect.<br />Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.<br /><br />Deprecated: This field is ignored. Use DualStackAddressFamily instead. | false |  |
 | `dualStackAddressFamily` _boolean_ | To set if we want to enable the neighbor not only for the ipfamily related to its session,<br />but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa. | false |  |
 
 

--- a/api/v1beta1/frrconfiguration_types.go
+++ b/api/v1beta1/frrconfiguration_types.go
@@ -195,9 +195,10 @@ type Neighbor struct {
 	// +optional
 	ToReceive Receive `json:"toReceive,omitempty"`
 
-	// To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+	// DisableMP is no longer used and has no effect.
+	// Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.
 	//
-	// Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+	// Deprecated: This field is ignored. Use DualStackAddressFamily instead.
 	// +optional
 	// +kubebuilder:default:=false
 	DisableMP bool `json:"disableMP,omitempty"`

--- a/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
@@ -185,10 +185,11 @@ spec:
                               disableMP:
                                 default: false
                                 description: |-
-                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                                  DisableMP is no longer used and has no effect.
+                                  Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.
 
 
-                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                                  Deprecated: This field is ignored. Use DualStackAddressFamily instead.
                                 type: boolean
                               dualStackAddressFamily:
                                 default: false

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -277,10 +277,11 @@ spec:
                               disableMP:
                                 default: false
                                 description: |-
-                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                                  DisableMP is no longer used and has no effect.
+                                  Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.
 
 
-                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                                  Deprecated: This field is ignored. Use DualStackAddressFamily instead.
                                 type: boolean
                               dualStackAddressFamily:
                                 default: false

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -277,10 +277,11 @@ spec:
                               disableMP:
                                 default: false
                                 description: |-
-                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                                  DisableMP is no longer used and has no effect.
+                                  Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.
 
 
-                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                                  Deprecated: This field is ignored. Use DualStackAddressFamily instead.
                                 type: boolean
                               dualStackAddressFamily:
                                 default: false

--- a/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
@@ -185,10 +185,11 @@ spec:
                               disableMP:
                                 default: false
                                 description: |-
-                                  To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
+                                  DisableMP is no longer used and has no effect.
+                                  Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.
 
 
-                                  Deprecated: DisableMP is deprecated in favor of dualStackAddressFamily.
+                                  Deprecated: This field is ignored. Use DualStackAddressFamily instead.
                                 type: boolean
                               dualStackAddressFamily:
                                 default: false

--- a/internal/webhooks/frrconfiguration_webhook.go
+++ b/internal/webhooks/frrconfiguration_webhook.go
@@ -155,7 +155,7 @@ func validateConfig(frrConfig *v1beta1.FRRConfiguration) ([]string, error) {
 	}
 
 	if containsDisableMP(frrConfig.Spec.BGP.Routers) {
-		warnings = append(warnings, "disableMP is deprecated and will be removed in a future release")
+		warnings = append(warnings, "disableMP is deprecated, is ignored and will be removed in a future release")
 	}
 
 	existingFRRConfigurations, err := getFRRConfigurations()

--- a/internal/webhooks/frrconfiguration_webhook_test.go
+++ b/internal/webhooks/frrconfiguration_webhook_test.go
@@ -260,7 +260,7 @@ func TestValidateFRRConfiguration(t *testing.T) {
 				},
 			},
 			failValidate: false,
-			warnings:     []string{"disableMP is deprecated and will be removed in a future release"},
+			warnings:     []string{"disableMP is deprecated, is ignored and will be removed in a future release"},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Update the DisableMP field documentation to clearly state that it has no effect and is completely ignored by the implementation. The previous documentation only mentioned deprecation without clearly indicating the field is non-functional.

Reported-at: https://github.com/metallb/frr-k8s/issues/387



**Is this a BUG FIX or a FEATURE ?**:


/kind documentation

**What this PR does / why we need it**:

Fixes https://github.com/metallb/frr-k8s/issues/387
Part of larger investigation for https://issues.redhat.com/browse/OCPBUGS-70258

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
Update the DisableMP field documentation to clearly state that it has no
effect and is completely ignored by the implementation. The previous
documentation only mentioned deprecation without clearly indicating the
field is non-functional.
```
