### PR TITLE
Fix build make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,10 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: manifests generate fmt vet ## Build k8s-frr binary.
-	go build -o bin/frr-k8s cmd/main.go
+	go build -v -o bin/frr-k8s ./cmd/frr-k8s-controller
+	go build -v -o bin/frr-metrics ./cmd/metrics
+	go build -v -o bin/frr-status ./cmd/status
+	go build -v -o bin/statuscleaner ./cmd/statuscleaner
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.


### PR DESCRIPTION
This commit fixes the `build` Make target. The target isn't really used
anywhere, but can be used for sanity checks for quick builds on the
local system without Docker / podman: Instead of only building frr-k8s,
also build the other 3 binaries (frr-metrics, frr-status,
statuscleaner).

/kind cleanup

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

```
