### PR TITLE
Add checkgenerated target and use that in ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,22 +50,7 @@ jobs:
           cache: true
       - name: Check Generated
         run: |
-          make bumplicense
-          go mod tidy
-          pushd e2etests
-          go mod tidy
-          popd
-          make manifests
-          make generate
-          make generate-all-in-one
-          make api-docs
-          make checkuncommitted
-
-      - name: Helm doc generate
-        uses: docker://jnorwood/helm-docs:v1.10.0
-
-      - name: Check if docs are different
-        run: make checkuncommitted
+          make checkgenerated
 
   commitlint:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -307,3 +307,10 @@ cutrelease: bumpversion generate-all-in-one helm-docs
 .PHONY: demoenv
 demoenv: deploy
 	cd hack/demo && ./demo.sh
+
+.PHONY: tidye2e
+tidye2e:
+	cd e2etests && go mod tidy
+
+.PHONY: checkgenerated
+checkgenerated: bumpall tidye2e generate generate-all-in-one api-docs helm-docs checkuncommitted ## Check all generated content.


### PR DESCRIPTION
The new checkgenerated Make target bundles a bunch of commands that were only run in github CI. By making this a Make target, it's now possible to run all of these commands locally for verification before pushing.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind cleanup

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

I personally prefer having a one-stop-shop before pushing.

Whereas I can remember `make checkgenerated`, I have a hard time remembering running:

```
pushd e2etests; go mod tidy; popd; make bumpall; make generate; make generate-all-in-one; make api-docs; make helm-docs; make checkuncommitted
```

It's not super important to me, I can just create a bash function for myself, but I'd prefer having it as a Make target

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
