### PR TITLE
bgp: add localASN field to Neighbor for per-peer local-as override

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -406,6 +406,7 @@ _Appears in:_
 | `toReceive` _[Receive](#receive)_ | ToReceive represents the list of prefixes to receive from the given neighbor. |  | Optional: \{\} <br /> |
 | `disableMP` _boolean_ | DisableMP is no longer used and has no effect.<br />Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.<br />Deprecated: This field is ignored. Use DualStackAddressFamily instead. | false | Optional: \{\} <br /> |
 | `dualStackAddressFamily` _boolean_ | To set if we want to enable the neighbor not only for the ipfamily related to its session,<br />but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa. | false | Optional: \{\} <br /> |
+| `localASN` _integer_ | LocalASN allows advertising a different AS number to the peer using BGP's<br />local-as feature. When set, FRR will advertise this ASN to the peer<br />via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding<br />the router-level ASN for this specific session.<br />Note: this field is only applicable to eBGP sessions (where the peer ASN differs<br />from the router ASN). Setting it on an iBGP session is rejected. |  | Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Optional: \{\} <br /> |
 
 
 #### PrefixSelector

--- a/api/v1beta1/frrconfiguration_types.go
+++ b/api/v1beta1/frrconfiguration_types.go
@@ -208,6 +208,17 @@ type Neighbor struct {
 	// +optional
 	// +kubebuilder:default:=false
 	DualStackAddressFamily bool `json:"dualStackAddressFamily,omitempty"`
+
+	// LocalASN allows advertising a different AS number to the peer using BGP's
+	// local-as feature. When set, FRR will advertise this ASN to the peer
+	// via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+	// the router-level ASN for this specific session.
+	// Note: this field is only applicable to eBGP sessions (where the peer ASN differs
+	// from the router ASN). Setting it on an iBGP session is rejected.
+	// +optional
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=4294967295
+	LocalASN uint32 `json:"localASN,omitempty"`
 }
 
 // Advertise represents a list of prefixes to advertise to the given neighbor.

--- a/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
@@ -238,6 +238,18 @@ spec:
                                   KeepaliveTime is the requested BGP keepalive time, per RFC4271.
                                   Defaults to 60s.
                                 type: string
+                              localASN:
+                                description: |-
+                                  LocalASN allows advertising a different AS number to the peer using BGP's
+                                  local-as feature. When set, FRR will advertise this ASN to the peer
+                                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                                  the router-level ASN for this specific session.
+                                  Note: this field is only applicable to eBGP sessions (where the peer ASN differs
+                                  from the router ASN). Setting it on an iBGP session is rejected.
+                                format: int32
+                                maximum: 4294967295
+                                minimum: 1
+                                type: integer
                               password:
                                 description: |-
                                   Password to be used for establishing the BGP session.

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -330,6 +330,18 @@ spec:
                                   KeepaliveTime is the requested BGP keepalive time, per RFC4271.
                                   Defaults to 60s.
                                 type: string
+                              localASN:
+                                description: |-
+                                  LocalASN allows advertising a different AS number to the peer using BGP's
+                                  local-as feature. When set, FRR will advertise this ASN to the peer
+                                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                                  the router-level ASN for this specific session.
+                                  Note: this field is only applicable to eBGP sessions (where the peer ASN differs
+                                  from the router ASN). Setting it on an iBGP session is rejected.
+                                format: int32
+                                maximum: 4294967295
+                                minimum: 1
+                                type: integer
                               password:
                                 description: |-
                                   Password to be used for establishing the BGP session.

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -330,6 +330,18 @@ spec:
                                   KeepaliveTime is the requested BGP keepalive time, per RFC4271.
                                   Defaults to 60s.
                                 type: string
+                              localASN:
+                                description: |-
+                                  LocalASN allows advertising a different AS number to the peer using BGP's
+                                  local-as feature. When set, FRR will advertise this ASN to the peer
+                                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                                  the router-level ASN for this specific session.
+                                  Note: this field is only applicable to eBGP sessions (where the peer ASN differs
+                                  from the router ASN). Setting it on an iBGP session is rejected.
+                                format: int32
+                                maximum: 4294967295
+                                minimum: 1
+                                type: integer
                               password:
                                 description: |-
                                   Password to be used for establishing the BGP session.

--- a/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
@@ -238,6 +238,18 @@ spec:
                                   KeepaliveTime is the requested BGP keepalive time, per RFC4271.
                                   Defaults to 60s.
                                 type: string
+                              localASN:
+                                description: |-
+                                  LocalASN allows advertising a different AS number to the peer using BGP's
+                                  local-as feature. When set, FRR will advertise this ASN to the peer
+                                  via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding
+                                  the router-level ASN for this specific session.
+                                  Note: this field is only applicable to eBGP sessions (where the peer ASN differs
+                                  from the router ASN). Setting it on an iBGP session is rejected.
+                                format: int32
+                                maximum: 4294967295
+                                minimum: 1
+                                type: integer
                               password:
                                 description: |-
                                   Password to be used for establishing the BGP session.

--- a/e2etests/tests/session.go
+++ b/e2etests/tests/session.go
@@ -331,5 +331,91 @@ var _ = ginkgo.Describe("Session", func() {
 			ginkgo.Entry("IPV4", ipfamily.IPv4),
 			ginkgo.Entry("IPV6", ipfamily.IPv6),
 		)
+
+		ginkgo.DescribeTable("Establishes sessions with localASN override", func(family ipfamily.Family) {
+			localASN := uint32(64520)
+
+			allFRRs := config.ContainersForVRF(infra.FRRContainers, "")
+			frrs := []*frrcontainer.FRR{}
+			for _, f := range allFRRs {
+				if f.RouterConfig.ASN != infra.FRRK8sASN {
+					frrs = append(frrs, f)
+				}
+			}
+			neighbors := []frrk8sv1beta1.Neighbor{}
+
+			for _, f := range frrs {
+				addresses := f.AddressesForFamily(family)
+				ebgpMultihop := false
+				if f.NeighborConfig.MultiHop && f.NeighborConfig.ASN != f.RouterConfig.ASN {
+					ebgpMultihop = true
+				}
+
+				for _, address := range addresses {
+					neighbors = append(neighbors, frrk8sv1beta1.Neighbor{
+						ASN:          f.RouterConfig.ASN,
+						Address:      address,
+						Password:     f.RouterConfig.Password,
+						Port:         &f.RouterConfig.BGPPort,
+						EBGPMultiHop: ebgpMultihop,
+						LocalASN:     localASN,
+					})
+				}
+			}
+
+			frrConfig := frrk8sv1beta1.FRRConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: k8s.FRRK8sNamespace,
+				},
+				Spec: frrk8sv1beta1.FRRConfigurationSpec{
+					BGP: frrk8sv1beta1.BGPConfig{
+						Routers: []frrk8sv1beta1.Router{
+							{
+								ASN:       infra.FRRK8sASN,
+								VRF:       "",
+								Neighbors: neighbors,
+							},
+						},
+					},
+				},
+			}
+
+			ginkgo.By("configuring FRR containers to expect localASN as frr-k8s's remote AS")
+			for _, c := range frrs {
+				err := frrcontainer.PairWithNodes(cs, c, family, func(frr *frrcontainer.FRR) {
+					frr.NeighborConfig.ASN = localASN
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			err := updater.Update([]corev1.Secret{}, frrConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			nodes, err := k8s.Nodes(cs)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("validating sessions are established and peers report localASN as the remote AS")
+			for _, c := range frrs {
+				Eventually(func() error {
+					neighbors, err := frr.NeighborsInfo(c)
+					if err != nil {
+						return err
+					}
+					if err = frr.NeighborsMatchNodes(nodes, neighbors, family, c.RouterConfig.VRF); err != nil {
+						return fmt.Errorf("failed to match neighbors for %s: %w", c.Name, err)
+					}
+					for _, n := range neighbors {
+						if n.RemoteAS != fmt.Sprintf("%d", localASN) {
+							return fmt.Errorf("expected peer %s to report remote AS %d, got %s", n.ID, localASN, n.RemoteAS)
+						}
+					}
+					return nil
+				}, 4*time.Minute, time.Second).ShouldNot(HaveOccurred())
+			}
+		},
+			ginkgo.Entry("IPV4", ipfamily.IPv4),
+			ginkgo.Entry("IPV6", ipfamily.IPv6),
+		)
 	})
 })

--- a/internal/controller/api_to_config.go
+++ b/internal/controller/api_to_config.go
@@ -136,6 +136,9 @@ func routerToFRRConfig(r v1beta1.Router, alwaysBlock []frr.IncomingFilter, secre
 	}
 
 	for _, n := range r.Neighbors {
+		if n.LocalASN != 0 && n.ASN != 0 && n.ASN == r.ASN {
+			return nil, fmt.Errorf("neighbor %s: localASN is not supported for iBGP sessions (neighbor ASN %d equals router ASN)", neighborName(n), n.ASN)
+		}
 		frrNeigh, err := neighborToFRR(n, routerPrefixes, alwaysBlock, r.VRF, secrets, bfdProfiles)
 		if err != nil {
 			return nil, fmt.Errorf("failed to process neighbor %s for router %d-%s: %w", neighborName(n), r.ASN, r.VRF, err)
@@ -181,6 +184,7 @@ func neighborToFRR(n v1beta1.Neighbor, prefixesInRouter []string, alwaysBlock []
 	res := &frr.NeighborConfig{
 		Name:            neighborName(n),
 		ASN:             asnFor(n),
+		LocalASN:        n.LocalASN,
 		SrcAddr:         n.SourceAddress,
 		Addr:            n.Address,
 		Iface:           n.Interface,

--- a/internal/controller/api_to_config_test.go
+++ b/internal/controller/api_to_config_test.go
@@ -2594,6 +2594,34 @@ func TestConversion(t *testing.T) {
 			err:     errors.New("neighbor internal@192.0.2.22 has both ASN and DynamicASN specified"),
 		},
 		{
+			name: "Neighbor with localASN on iBGP session is rejected",
+			fromK8s: []v1beta1.FRRConfiguration{
+				{
+					Spec: v1beta1.FRRConfigurationSpec{
+						BGP: v1beta1.BGPConfig{
+							Routers: []v1beta1.Router{
+								{
+									ASN: 65010,
+									ID:  "192.0.2.5",
+									VRF: "",
+									Neighbors: []v1beta1.Neighbor{
+										{
+											Address:  "192.0.2.22",
+											ASN:      65010,
+											LocalASN: 64520,
+										},
+									},
+									Prefixes: []string{"192.0.2.0/24"},
+								},
+							},
+						},
+					},
+				},
+			},
+			secrets: map[string]v1.Secret{},
+			err:     errors.New("neighbor 65010@192.0.2.22: localASN is not supported for iBGP sessions (neighbor ASN 65010 equals router ASN)"),
+		},
+		{
 			name: "Neighbor with DynamicASN",
 			fromK8s: []v1beta1.FRRConfiguration{
 				{

--- a/internal/controller/merge.go
+++ b/internal/controller/merge.go
@@ -281,6 +281,10 @@ func neighborsAreCompatible(n1, n2 *frr.NeighborConfig) error {
 		return fmt.Errorf("multiple connect times specified for %s", neighborKey)
 	}
 
+	if n1.LocalASN != n2.LocalASN {
+		return fmt.Errorf("multiple localASNs specified for %s", neighborKey)
+	}
+
 	return nil
 }
 

--- a/internal/controller/merge_test.go
+++ b/internal/controller/merge_test.go
@@ -1240,6 +1240,60 @@ func TestMergeNeighbors(t *testing.T) {
 			},
 			err: fmt.Errorf("got multiple bfd profiles specified for %s", "192.0.2.0"),
 		},
+		{
+			name: "LocalASN, both specify same value",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      "65040",
+					Addr:     "192.0.1.20",
+					LocalASN: 64520,
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      "65040",
+					Addr:     "192.0.1.20",
+					LocalASN: 64520,
+				},
+			},
+			expected: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      "65040",
+					Addr:     "192.0.1.20",
+					LocalASN: 64520,
+					Outgoing: frr.AllowedOut{},
+					Incoming: frr.AllowedIn{},
+				},
+			},
+		},
+		{
+			name: "LocalASN, both specify different values",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      "65040",
+					Addr:     "192.0.1.20",
+					LocalASN: 64520,
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      "65040",
+					Addr:     "192.0.1.20",
+					LocalASN: 64521,
+				},
+			},
+			err: fmt.Errorf("multiple localASNs specified for %s", "65040@192.0.1.20"),
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/frr/config.go
+++ b/internal/frr/config.go
@@ -80,6 +80,7 @@ type NeighborConfig struct {
 	BFDProfile      string
 	GracefulRestart bool
 	EBGPMultiHop    bool
+	LocalASN        uint32
 	VRFName         string
 	Incoming        AllowedIn
 	Outgoing        AllowedOut

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -806,6 +806,39 @@ func TestSingleSessionWithGracefulRestart(t *testing.T) {
 	testCheckConfigFile(t)
 }
 
+func TestSingleSessionWithLocalASN(t *testing.T) {
+	testSetup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily: ipfamily.IPv4,
+						ASN:      "65001",
+						Addr:     "192.168.1.2",
+						LocalASN: 65410,
+					},
+				},
+			},
+		},
+		Loglevel: LevelFrom(logging.LevelInfo),
+	}
+
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
 func TestMultipleRoutersImportVRFs(t *testing.T) {
 	testSetup(t)
 

--- a/internal/frr/templates/neighborsession.tmpl
+++ b/internal/frr/templates/neighborsession.tmpl
@@ -12,6 +12,9 @@
   {{- if .neighbor.EBGPMultiHop }}
   neighbor {{$peer}} ebgp-multihop
   {{- end }}
+  {{- if .neighbor.LocalASN }}
+  neighbor {{$peer}} local-as {{.neighbor.LocalASN}} no-prepend replace-as
+  {{- end }}
   {{ if .neighbor.Port -}}
   neighbor {{$peer}} port {{.neighbor.Port}}
   {{- end }}

--- a/internal/frr/testdata/TestSingleSessionWithLocalASN.golden
+++ b/internal/frr/testdata/TestSingleSessionWithLocalASN.golden
@@ -1,0 +1,50 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 192.168.1.2-allowed-ipv4 seq 1 deny any
+
+
+ipv6 prefix-list 192.168.1.2-allowed-ipv6 seq 1 deny any
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-allowed-ipv4
+
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-allowed-ipv6
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  neighbor 192.168.1.2 remote-as 65001
+  neighbor 192.168.1.2 local-as 65410 no-prepend replace-as
+  
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+  exit-address-family
+


### PR DESCRIPTION
Add an optional LocalASN field to the Neighbor API type that instructs FRR to advertise a different ASN to a specific peer via: neighbor <peer> local-as <ASN> no-prepend replace-as

this is same as this pr https://github.com/metallb/metallb/pull/2997 

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
> /kind bug
> /kind cleanup

/kind feature

> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note

Add `localASN` field to `Neighbor` to advertise a different AS number to a specific peer via FRR's `local-as no-prepend replace-as` feature.

```
