### PR TITLE
CI: add a daily ci run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ on:
       - "main"
       - "v**"
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Having a periodic run is needed because:
1. in our CI we fetch the metallb main branch, so if something breaks it will only be visible when a new PR lands in the repo.
2. flakes will be found.

Revives #325.

/kind cleanup