### PR TITLE
Generate fallback BGP router-id on IPv6-only nodes

### DIFF
--- a/cmd/frr-k8s-controller/main.go
+++ b/cmd/frr-k8s-controller/main.go
@@ -206,7 +206,11 @@ func startFRRControllers(ctx context.Context, mgr manager.Manager, params params
 	}
 	setupLog.Info("using BGP debounce timeout", "milliseconds", dbTimeout.Milliseconds())
 
-	frrInstance := frr.NewFRR(ctx, reloadStatus, dbTimeout)
+	frrInstance, err := frr.NewFRR(ctx, reloadStatus, dbTimeout)
+	if err != nil {
+		setupLog.Error(err, "failed to create FRR instance")
+		os.Exit(1)
+	}
 
 	alwaysBlock, err := parseCIDRs(params.alwaysBlockCIDRs)
 	if err != nil {

--- a/internal/frr/frr.go
+++ b/internal/frr/frr.go
@@ -4,7 +4,10 @@ package frr
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"hash/crc32"
+	"net"
 	"os"
 	"strings"
 	"sync"
@@ -31,9 +34,10 @@ type Status struct {
 }
 
 type FRR struct {
-	reloadConfig    chan reloadEvent
-	Status          Status
-	onStatusChanged StatusChanged
+	reloadConfig     chan reloadEvent
+	Status           Status
+	onStatusChanged  StatusChanged
+	fallbackRouterID string
 	sync.Mutex
 }
 
@@ -51,21 +55,64 @@ func (f *FRR) ApplyConfig(config *Config) error {
 
 	// TODO add internal wrapper
 	config.Hostname = hostname
+	if f.fallbackRouterID != "" {
+		for _, r := range config.Routers {
+			if r.RouterID == "" {
+				r.RouterID = f.fallbackRouterID
+			}
+		}
+	}
 	f.reloadConfig <- reloadEvent{config: config}
 	return nil
 }
 
+var netInterfaceAddrs = net.InterfaceAddrs
+
+func hasIPv4Address() bool {
+	addrs, err := netInterfaceAddrs()
+	if err != nil {
+		return false
+	}
+	for _, a := range addrs {
+		if ipnet, ok := a.(*net.IPNet); ok && ipnet.IP.To4() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hashRouterID() (string, error) {
+	hostname, err := osHostname()
+	if err != nil {
+		return "", err
+	}
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, crc32.ChecksumIEEE([]byte(hostname)))
+	return net.IP(b).String(), nil
+}
+
 var failureTimeout = time.Second * 5
 
-func NewFRR(ctx context.Context, onStatusChanged StatusChanged, debounceTimeout time.Duration) *FRR {
+func NewFRR(ctx context.Context, onStatusChanged StatusChanged, debounceTimeout time.Duration) (*FRR, error) {
+	l := logging.GetLogger()
 	res := &FRR{
 		reloadConfig:    make(chan reloadEvent),
 		onStatusChanged: onStatusChanged,
 	}
 
+	// On IPv6-only nodes, FRR defaults router-id to 0.0.0.0 (RFC 6286 violation).
+	if !hasIPv4Address() {
+		routerID, err := hashRouterID()
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate fallback router-id: %w", err)
+		}
+		res.fallbackRouterID = routerID
+		level.Info(l).Log("op", "startup", "msg", "no IPv4 address found, using fallback router-id", "routerID", res.fallbackRouterID)
+	}
+
 	debouncer(ctx, generateAndReloadConfigFile, res.reloadConfig, debounceTimeout, failureTimeout)
 	res.pollStatus(ctx)
-	return res
+	return res, nil
 }
 
 func (f *FRR) GetStatus() Status {

--- a/internal/frr/frr_bfd_test.go
+++ b/internal/frr/frr_bfd_test.go
@@ -14,7 +14,7 @@ import (
 func TestSingleSessionBFD(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, func() {}, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -58,7 +58,7 @@ func TestSingleSessionBFD(t *testing.T) {
 func TestTwoRoutersTwoNeighborsBFD(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, func() {}, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,6 +83,15 @@ func testSetup(t *testing.T) {
 	osHostname = testOsHostname
 }
 
+func testNewFRR(t *testing.T, ctx context.Context) *FRR {
+	t.Helper()
+	frr, err := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	if err != nil {
+		t.Fatalf("Failed to create FRR instance: %s", err)
+	}
+	return frr
+}
+
 func testCheckConfigFile(t *testing.T) {
 	configFile, goldenFile := testGenerateFileNames(t)
 
@@ -104,7 +114,7 @@ var emptyCB = func() {}
 func TestSingleSession(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -141,7 +151,7 @@ func TestSingleSession(t *testing.T) {
 func TestTwoRoutersTwoNeighbors(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -207,7 +217,7 @@ func TestTwoRoutersTwoNeighbors(t *testing.T) {
 func TestTwoSessionsAcceptAll(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -246,7 +256,7 @@ func TestTwoSessionsAcceptAll(t *testing.T) {
 func TestTwoSessionsAcceptSomeV4(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -299,7 +309,7 @@ func TestTwoSessionsAcceptSomeV4(t *testing.T) {
 func TestTwoSessionsAcceptV4AndV6(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -419,7 +429,7 @@ func TestSingleSessionWithEBGPMultihop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -457,7 +467,7 @@ func TestSingleSessionWithIPv6SingleHop(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -495,7 +505,7 @@ func TestMultipleNeighborsOneV4AndOneV6(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -544,7 +554,7 @@ func TestMultipleNeighborsOneV4AndOneV6DualStackIPFamily(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -592,7 +602,7 @@ func TestMultipleRoutersMultipleNeighs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -668,7 +678,7 @@ func TestSingleSessionWithEBGPMultihopAndExtras(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -707,7 +717,7 @@ func TestSingleSessionWithAlwaysBlock(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -779,7 +789,7 @@ func TestSingleSessionWithGracefulRestart(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -812,7 +822,7 @@ func TestSingleSessionWithLocalASN(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -845,7 +855,7 @@ func TestMultipleRoutersImportVRFs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 
 	config := Config{
 		Routers: []*RouterConfig{
@@ -890,7 +900,7 @@ func TestMultipleRoutersImportVRFs(t *testing.T) {
 func TestSingleSessionWithInternalASN(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -925,7 +935,7 @@ func TestSingleSessionWithInternalASN(t *testing.T) {
 func TestSingleSessionWithExternalASN(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -959,7 +969,7 @@ func TestSingleSessionWithExternalASN(t *testing.T) {
 func TestSingleUnnumberedSession(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
@@ -999,11 +1009,89 @@ func TestSingleUnnumberedSession(t *testing.T) {
 func TestLogLevelDebugging(t *testing.T) {
 	testSetup(t)
 	ctx, cancel := context.WithCancel(context.Background())
-	frr := NewFRR(ctx, emptyCB, testDebounceTimeout)
+	frr := testNewFRR(t, ctx)
 	defer cancel()
 
 	config := Config{
 		Loglevel: LevelFrom(logging.LevelDebug),
+	}
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionExplicitRouterID(t *testing.T) {
+	testSetup(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	frr := testNewFRR(t, ctx)
+	defer cancel()
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN:    65000,
+				RouterID: "10.10.10.1",
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily: ipfamily.IPv4,
+						ASN:      "65001",
+						Addr:     "192.168.1.2",
+						Port:     ptr.To[uint16](4567),
+						Outgoing: AllowedOut{
+							PrefixesV4: []string{
+								"192.169.1.0/24",
+							},
+						},
+					},
+				},
+				IPV4Prefixes: []string{"192.169.1.0/24"},
+			},
+		},
+		Loglevel: LevelFrom(logging.LevelInfo),
+	}
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionIPv6OnlyNode(t *testing.T) {
+	testSetup(t)
+	netInterfaceAddrs = func() ([]net.Addr, error) {
+		return nil, nil
+	}
+	t.Cleanup(func() { netInterfaceAddrs = net.InterfaceAddrs })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	frr := testNewFRR(t, ctx)
+	defer cancel()
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily: ipfamily.IPv6,
+						ASN:      "65001",
+						Addr:     "2001:db8::1",
+						Port:     ptr.To[uint16](179),
+						Outgoing: AllowedOut{
+							PrefixesV6: []string{
+								"2001:db8:1::/64",
+							},
+						},
+					},
+				},
+				IPV6Prefixes: []string{"2001:db8:1::/64"},
+			},
+		},
+		Loglevel: LevelFrom(logging.LevelInfo),
 	}
 	err := frr.ApplyConfig(&config)
 	if err != nil {

--- a/internal/frr/testdata/TestSingleSessionExplicitRouterID.golden
+++ b/internal/frr/testdata/TestSingleSessionExplicitRouterID.golden
@@ -1,0 +1,54 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 192.168.1.2-allowed-ipv4 seq 1 permit 192.169.1.0/24
+
+
+ipv6 prefix-list 192.168.1.2-allowed-ipv6 seq 1 deny any
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-allowed-ipv4
+
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-allowed-ipv6
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  bgp router-id 10.10.10.1
+  neighbor 192.168.1.2 remote-as 65001
+  neighbor 192.168.1.2 port 4567
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+  exit-address-family
+  address-family ipv4 unicast
+    network 192.169.1.0/24
+  exit-address-family
+
+

--- a/internal/frr/testdata/TestSingleSessionIPv6OnlyNode.golden
+++ b/internal/frr/testdata/TestSingleSessionIPv6OnlyNode.golden
@@ -1,0 +1,55 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 2001:db8::1-allowed-ipv4 seq 1 deny any
+
+
+ipv6 prefix-list 2001:db8::1-allowed-ipv6 seq 1 permit 2001:db8:1::/64
+
+route-map 2001:db8::1-out permit 1
+  match ip address prefix-list 2001:db8::1-allowed-ipv4
+
+route-map 2001:db8::1-out permit 2
+  match ipv6 address prefix-list 2001:db8::1-allowed-ipv6
+
+
+
+
+
+ip prefix-list 2001:db8::1-inpl-ipv6 seq 1 deny any
+
+ipv6 prefix-list 2001:db8::1-inpl-ipv6 seq 2 deny any
+route-map 2001:db8::1-in permit 3
+  match ip address prefix-list 2001:db8::1-inpl-ipv6
+route-map 2001:db8::1-in permit 4
+  match ipv6 address prefix-list 2001:db8::1-inpl-ipv6
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  bgp router-id 167.62.253.30
+  neighbor 2001:db8::1 remote-as 65001
+  neighbor 2001:db8::1 port 179
+  
+  
+  
+  neighbor 2001:db8::1 disable-connected-check
+
+  address-family ipv6 unicast
+    neighbor 2001:db8::1 activate
+    neighbor 2001:db8::1 route-map 2001:db8::1-in in
+    neighbor 2001:db8::1 route-map 2001:db8::1-out out
+  exit-address-family
+  address-family ipv6 unicast
+    network 2001:db8:1::/64
+  exit-address-family
+
+


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:
On IPv6 single-stack clusters where nodes have no IPv4 addresses, FRR defaults the BGP router-id to 0.0.0.0. This violates RFC 6286 and RFC 4271, causing remote peers to reject the session with "Bad BGP Identifier".

Derive a deterministic router-id from the node hostname using CRC32 when no explicit router-id is configured, matching the approach already used by MetalLB's native BGP implementation.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
When no explicit BGP router-id is configured, frr-k8s now derives a deterministic router-id from the node hostname, fixing BGP session establishment failures on IPv6 single-stack clusters where FRR would default to the invalid 0.0.0.0 identifier.
```
