### PR TITLE
fix(chart): correct values.schema.json structure and types

### DIFF
--- a/charts/frr-k8s/values.schema.json
+++ b/charts/frr-k8s/values.schema.json
@@ -240,7 +240,7 @@
             "interval": {
               "anyOf": [
                 {
-                  "type": "integer"
+                  "type": "string"
                 },
                 {
                   "type": "null"
@@ -261,100 +261,6 @@
             }
           }
         }
-      },
-      "frrk8s": {
-        "allOf": [
-          {
-            "$ref": "#/definitions/component"
-          },
-          {
-            "description": "FRR-K8s controller",
-            "type": "object",
-            "properties": {
-              "tolerateMaster": {
-                "type": "boolean"
-              },
-              "updateStrategy": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "type"
-                ]
-              },
-              "runtimeClassName": {
-                "type": "string"
-              },
-              "secretName": {
-                "type": "string"
-              },
-              "frr": {
-                "description": "The FRR properties in the controller",
-                "type": "object",
-                "properties": {
-                  "image": {
-                    "$ref": "#/definitions/component/properties/image"
-                  },
-                  "metricsPort": {
-                    "type": "integer"
-                  },
-                  "secureMetricsPort": {
-                    "type": "integer"
-                  },
-                  "resources:": {
-                    "type": "object"
-                  }
-                },
-                "required": [
-                  "enabled"
-                ]
-              },
-              "command": {
-                "type": "string"
-              },
-              "reloader": {
-                "type": "object",
-                "properties": {
-                  "resources": {
-                    "type": "object"
-                  }
-                }
-              },
-              "frrMetrics": {
-                "type": "object",
-                "properties": {
-                  "resources": {
-                    "type": "object"
-                  }
-                }
-              }
-            },
-            "required": [
-              "tolerateMaster"
-            ]
-          }
-        ]
-      },
-      "crds": {
-        "description": "CRD configuration",
-        "type": "object",
-        "properties": {
-          "enabled": {
-            "description": "Enable CRDs",
-            "type": "boolean"
-          },
-          "validationFailurePolicy": {
-            "description": "Failure policy to use with validating webhooks",
-            "type": "string",
-            "enum": [
-              "Ignore",
-              "Fail"
-            ]
-          }
-        }
       }
     },
     "frrk8s": {
@@ -363,9 +269,66 @@
           "$ref": "#/definitions/component"
         },
         {
-          "description": "FRRk8s Controller",
+          "description": "FRR-K8s controller",
           "type": "object",
           "properties": {
+            "tolerateMaster": {
+              "type": "boolean"
+            },
+            "updateStrategy": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "runtimeClassName": {
+              "type": "string"
+            },
+            "secretName": {
+              "type": "string"
+            },
+            "frr": {
+              "description": "The FRR properties in the controller",
+              "type": "object",
+              "properties": {
+                "image": {
+                  "$ref": "#/definitions/component/properties/image"
+                },
+                "metricsPort": {
+                  "type": "integer"
+                },
+                "secureMetricsPort": {
+                  "type": "integer"
+                },
+                "resources": {
+                  "type": "object"
+                }
+              }
+            },
+            "command": {
+              "type": "string"
+            },
+            "reloader": {
+              "type": "object",
+              "properties": {
+                "resources": {
+                  "type": "object"
+                }
+              }
+            },
+            "frrMetrics": {
+              "type": "object",
+              "properties": {
+                "resources": {
+                  "type": "object"
+                }
+              }
+            },
             "strategy": {
               "type": "object",
               "properties": {
@@ -377,15 +340,30 @@
                 "type"
               ]
             },
-            "command": {
-              "type": "string"
-            },
             "webhookMode": {
               "type": "string"
             }
           }
         }
       ]
+    },
+    "crds": {
+      "description": "CRD configuration",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enable CRDs",
+          "type": "boolean"
+        },
+        "validationFailurePolicy": {
+          "description": "Failure policy to use with validating webhooks",
+          "type": "string",
+          "enum": [
+            "Ignore",
+            "Fail"
+          ]
+        }
+      }
     }
   },
   "required": [


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

Four independent bugs in `charts/frr-k8s/values.schema.json` that together leave strictly-shaped chart inputs unvalidated, reject documented inputs, and bury a large `frrk8s` block in a schema-ignored position. Single-file diff.

1. JSON property key typo: `"resources:"` (with trailing colon).

   Pre-fix the property name under `frrk8s.frr.properties` had a stray colon, so the `resources` map under `frrk8s.frr` was effectively unschema'd. Rename to `"resources"`, matching the sibling shapes `frrk8s.reloader.resources`, `frrk8s.frrMetrics.resources`, `frrk8s.frrStatus.resources` in the same file.

2. `prometheus.serviceMonitor.interval` schema mismatch.

   Pre-fix declared `anyOf: integer | null`, but the Prometheus convention for scrape intervals is a duration string (`"30s"`, `"1m"`, etc.) and `charts/frr-k8s/README.md:86` already documents the field as `string`. Operators who set `prometheus.serviceMonitor.interval: 30s` were rejected by `helm template` with a schema error. Widen to `anyOf: string | null`.

3. `crds` block misplaced under `prometheus`.

   Pre-fix the `crds` schema lived at `properties.prometheus.crds`. JSON Schema silently ignores unknown sibling keys, so the entire top-level `crds` map in `values.yaml` was unvalidated — `crds.enabled: "not_a_bool"` was accepted without complaint. Move it to `properties.crds`; the schema now catches type errors on `crds.enabled` and constrains `crds.validationFailurePolicy` to the documented enum `Ignore | Fail`.

4. `frrk8s` block misplaced under `prometheus`.

   Pre-fix an entire `frrk8s` definition (`tolerateMaster`, `updateStrategy`, `runtimeClassName`, `secretName`, `frr.{image, metricsPort, secureMetricsPort, resources}`, `command`, `reloader`, `frrMetrics`) lived at `properties.prometheus.frrk8s` — a sibling of `properties` inside the `prometheus` block. Same JSON-Schema silent-ignore as #3: the chart's actual `frrk8s.*` values went unvalidated. Merge the misplaced block into the existing top-level `properties.frrk8s` (which previously held only `strategy`, `command`, `webhookMode`). The `frr.required: [enabled]` rule is dropped during the move because the chart's own `values.yaml` does not set `frrk8s.frr.enabled` — enforcing it would reject the chart's default render with a confusing "missing property" error, which the pre-fix schema avoided by being in a position the validator ignored.

**Special notes for your reviewer**:

Verified locally (helm v3.18, v3.21):

Pre-fix:

- `helm template ... --set prometheus.serviceMonitor.interval=30s` → rejected ("got string, want integer").
- `helm template ... --set crds.enabled=not_a_bool` → silently accepted.
- `helm template ... --set frrk8s.tolerateMaster=not_a_bool` → silently accepted.

Post-fix:

- `interval=30s` → accepted.
- `crds.enabled=not_a_bool` → rejected: `at '/crds/enabled': got string, want boolean`.
- `frrk8s.tolerateMaster=not_a_bool` → rejected: `at '/frrk8s/tolerateMaster': got string, want boolean`.
- Default `helm template charts/frr-k8s --set crds.enabled=true` renders cleanly (42 documents, 0 errors).
- `helm lint charts/frr-k8s --set crds.enabled=true` clean.

**Release note**:

```release-note
Fixed four bugs in the frr-k8s Helm chart values.schema.json: removed a trailing-colon typo on `frrk8s.frr.resources`; widened `prometheus.serviceMonitor.interval` to accept duration strings (matches Prometheus convention and the chart README); moved the `crds` block from under `prometheus` to top-level so `crds.enabled` and `crds.validationFailurePolicy` are now validated; merged the large `frrk8s` block (`tolerateMaster`, `updateStrategy`, `frr.*`, `reloader`, `frrMetrics`, etc.) into the top-level `frrk8s` schema so those fields are now validated as well.
```
