### PR TITLE
fix: support rolling updates of the statuscleaner

### DIFF
--- a/charts/frr-k8s/templates/status-cleaner.yaml
+++ b/charts/frr-k8s/templates/status-cleaner.yaml
@@ -13,6 +13,11 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: statuscleaner
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 100%
   template:
     metadata:
       annotations:


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind bug

Fixed #448

**What this PR does / why we need it**:

This makes it such that you can restart the statuscleaner on a single node cluster.

**Special notes for your reviewer**:

**Release note**:

```release-note
Allow restarting the statuscleaner on a single node cluster.
```
