### PR TITLE
Add linux/riscv64 build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -88,7 +88,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le,linux/arm/v7,linux/riscv64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: true

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -1298,6 +1298,7 @@ spec:
                 - amd64
                 - arm64
                 - ppc64le
+                - riscv64
                 - s390x
               - key: kubernetes.io/os
                 operator: In

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -1267,6 +1267,7 @@ spec:
                 - amd64
                 - arm64
                 - ppc64le
+                - riscv64
                 - s390x
               - key: kubernetes.io/os
                 operator: In

--- a/config/default/frr-k8s_auth_proxy_patch.yaml
+++ b/config/default/frr-k8s_auth_proxy_patch.yaml
@@ -20,6 +20,7 @@ spec:
                     - amd64
                     - arm64
                     - ppc64le
+                    - riscv64
                     - s390x
                 - key: kubernetes.io/os
                   operator: In


### PR DESCRIPTION
This works under Ubuntu 24.04, I hope the build under Ubuntu 22.04 (used in the pipeline currently) will get through.