### PR TITLE
fix(chart): correct fullnameOverride key casing in values.schema.json

### DIFF
--- a/charts/frr-k8s/values.schema.json
+++ b/charts/frr-k8s/values.schema.json
@@ -172,7 +172,7 @@
       "description": "Override chart name",
       "type": "string"
     },
-    "fullNameOverride": {
+    "fullnameOverride": {
       "description": "Override fully qualified app name",
       "type": "string"
     },


### PR DESCRIPTION
The schema declared `fullNameOverride` but values.yaml, templates, and README all use `fullnameOverride` (lowercase n), so the property went unvalidated. Rename to match.

Verified locally (helm v3.12.3):

Pre-fix:
- `helm template ... --set-json fullnameOverride=123` -> not caught by the schema; fails later during template rendering with a cryptic type error (_helpers.tpl:16:37 ... wrong type for value; expected string; got float64).
- `helm template ... --set-json fullNameOverride=123` -> rejected by the schema, i.e. it was validating a key the chart never reads.

Post-fix:
- `helm template ... --set-json fullnameOverride=123` -> rejected by the schema: `fullnameOverride: Invalid type. Expected: string, given: integer`.
- `helm template ... --set fullnameOverride=my-frrk8s` -> renders cleanly (48 manifests).
- `helm template charts/frr-k8s --set crds.enabled=true` -> clean default render.
- `helm lint charts/frr-k8s` -> clean.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:


/kind bug


```release-note
NONE
```
