### PR TITLE
Add AllowAsIn field to Neighbor FRRConfiguration

### DIFF
--- a/API-DOCS.md
+++ b/API-DOCS.md
@@ -70,6 +70,24 @@ _Appears in:_
 | `unicast` |  |
 
 
+#### AllowAsInMode
+
+_Underlying type:_ _string_
+
+AllowAsInMode specifies whether routes with the local AS in the path are accepted from a neighbor.
+
+_Validation:_
+- Enum: [ none origin 1 2 3 4 5 6 7 8 9 10]
+
+_Appears in:_
+- [Neighbor](#neighbor)
+
+| Field | Description |
+| --- | --- |
+| `none` |  |
+| `origin` |  |
+
+
 #### AllowedInPrefixes
 
 
@@ -535,6 +553,7 @@ _Appears in:_
 | `disableMP` _boolean_ | DisableMP is no longer used and has no effect.<br />Use DualStackAddressFamily instead to enable the neighbor for both IPv4 and IPv6 address families.<br />Deprecated: This field is ignored. Use DualStackAddressFamily instead. | false | Optional: \{\} <br /> |
 | `dualStackAddressFamily` _boolean_ | To set if we want to enable the neighbor not only for the ipfamily related to its session,<br />but also the other one. This allows to advertise/receive IPv4 prefixes over IPv6 sessions and vice versa. | false | Optional: \{\} <br /> |
 | `localASN` _integer_ | LocalASN allows advertising a different AS number to the peer using BGP's<br />local-as feature. When set, FRR will advertise this ASN to the peer<br />via "neighbor <peer> local-as <ASN> no-prepend replace-as", overriding<br />the router-level ASN for this specific session.<br />Note: this field is only applicable to eBGP sessions (where the peer ASN differs<br />from the router ASN). Setting it on an iBGP session is rejected. |  | Format: int64 <br />Maximum: 4.294967295e+09 <br />Minimum: 1 <br />Optional: \{\} <br /> |
+| `allowAsIn` _[AllowAsInMode](#allowasinmode)_ | AllowAsIn controls whether routes with the local AS number in the AS path<br />are accepted from this neighbor for the enabled address families.<br />This is useful in hub-and-spoke or route-leaking topologies where the<br />same AS number may appear multiple times in the path.<br />Possible values:<br />- "" (empty, default): routes with the local AS in the path are rejected.<br />  Does not reject other AllowAsIn values targeting the same neighbor.<br />- "none": routes with the local AS in the path are rejected.<br />  Rejects other AllowAsIn values targeting the same neighbor.<br />- "origin": routes are accepted only if the local AS appears as the origin (last AS in the path).<br />- "1"-"10": routes are accepted with up to this many occurrences of the local AS in the path.<br />When multiple configurations target the same neighbor, any combination of<br />values resolves to the least restrictive, except "none" which rejects<br />all other values. |  | Enum: [ none origin 1 2 3 4 5 6 7 8 9 10] <br />Optional: \{\} <br /> |
 | `addressFamilies` _[AddressFamily](#addressfamily) array_ | AddressFamilies specifies which address families to activate this neighbor for.<br />Supported values: "unicast" (IPv4/IPv6 unicast based on neighbor IP), "evpn" (L2VPN EVPN). | [unicast] | Enum: [unicast evpn] <br />MaxItems: 2 <br />Optional: \{\} <br /> |
 
 

--- a/api/v1beta1/frrconfiguration_types.go
+++ b/api/v1beta1/frrconfiguration_types.go
@@ -229,6 +229,23 @@ type Neighbor struct {
 	// +kubebuilder:validation:Format=int64
 	LocalASN uint32 `json:"localASN,omitempty"`
 
+	// AllowAsIn controls whether routes with the local AS number in the AS path
+	// are accepted from this neighbor for the enabled address families.
+	// This is useful in hub-and-spoke or route-leaking topologies where the
+	// same AS number may appear multiple times in the path.
+	// Possible values:
+	// - "" (empty, default): routes with the local AS in the path are rejected.
+	//   Does not reject other AllowAsIn values targeting the same neighbor.
+	// - "none": routes with the local AS in the path are rejected.
+	//   Rejects other AllowAsIn values targeting the same neighbor.
+	// - "origin": routes are accepted only if the local AS appears as the origin (last AS in the path).
+	// - "1"-"10": routes are accepted with up to this many occurrences of the local AS in the path.
+	// When multiple configurations target the same neighbor, any combination of
+	// values resolves to the least restrictive, except "none" which rejects
+	// all other values.
+	// +optional
+	AllowAsIn AllowAsInMode `json:"allowAsIn,omitempty"`
+
 	// AddressFamilies specifies which address families to activate this neighbor for.
 	// Supported values: "unicast" (IPv4/IPv6 unicast based on neighbor IP), "evpn" (L2VPN EVPN).
 	// +optional
@@ -466,6 +483,15 @@ type AddressFamily string
 const (
 	AddressFamilyUnicast AddressFamily = "unicast"
 	AddressFamilyEVPN    AddressFamily = "evpn"
+)
+
+// AllowAsInMode specifies whether routes with the local AS in the path are accepted from a neighbor.
+// +kubebuilder:validation:Enum="";none;origin;"1";"2";"3";"4";"5";"6";"7";"8";"9";"10"
+type AllowAsInMode string
+
+const (
+	AllowAsInNone   AllowAsInMode = "none"
+	AllowAsInOrigin AllowAsInMode = "origin"
 )
 
 // AdvertisePrefixType specifies a prefix type to advertise as EVPN type-5 routes.

--- a/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/charts/frr-k8s/charts/crds/templates/frrk8s.metallb.io_frrconfigurations.yaml
@@ -489,6 +489,37 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
+                              allowAsIn:
+                                description: |-
+                                  AllowAsIn controls whether routes with the local AS number in the AS path
+                                  are accepted from this neighbor for the enabled address families.
+                                  This is useful in hub-and-spoke or route-leaking topologies where the
+                                  same AS number may appear multiple times in the path.
+                                  Possible values:
+                                  - "" (empty, default): routes with the local AS in the path are rejected.
+                                    Does not reject other AllowAsIn values targeting the same neighbor.
+                                  - "none": routes with the local AS in the path are rejected.
+                                    Rejects other AllowAsIn values targeting the same neighbor.
+                                  - "origin": routes are accepted only if the local AS appears as the origin (last AS in the path).
+                                  - "1"-"10": routes are accepted with up to this many occurrences of the local AS in the path.
+                                  When multiple configurations target the same neighbor, any combination of
+                                  values resolves to the least restrictive, except "none" which rejects
+                                  all other values.
+                                enum:
+                                - ""
+                                - none
+                                - origin
+                                - "1"
+                                - "2"
+                                - "3"
+                                - "4"
+                                - "5"
+                                - "6"
+                                - "7"
+                                - "8"
+                                - "9"
+                                - "10"
+                                type: string
                               asn:
                                 description: |-
                                   ASN is the AS number to use for the local end of the session.

--- a/config/all-in-one/frr-k8s-prometheus.yaml
+++ b/config/all-in-one/frr-k8s-prometheus.yaml
@@ -581,6 +581,37 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
+                              allowAsIn:
+                                description: |-
+                                  AllowAsIn controls whether routes with the local AS number in the AS path
+                                  are accepted from this neighbor for the enabled address families.
+                                  This is useful in hub-and-spoke or route-leaking topologies where the
+                                  same AS number may appear multiple times in the path.
+                                  Possible values:
+                                  - "" (empty, default): routes with the local AS in the path are rejected.
+                                    Does not reject other AllowAsIn values targeting the same neighbor.
+                                  - "none": routes with the local AS in the path are rejected.
+                                    Rejects other AllowAsIn values targeting the same neighbor.
+                                  - "origin": routes are accepted only if the local AS appears as the origin (last AS in the path).
+                                  - "1"-"10": routes are accepted with up to this many occurrences of the local AS in the path.
+                                  When multiple configurations target the same neighbor, any combination of
+                                  values resolves to the least restrictive, except "none" which rejects
+                                  all other values.
+                                enum:
+                                - ""
+                                - none
+                                - origin
+                                - "1"
+                                - "2"
+                                - "3"
+                                - "4"
+                                - "5"
+                                - "6"
+                                - "7"
+                                - "8"
+                                - "9"
+                                - "10"
+                                type: string
                               asn:
                                 description: |-
                                   ASN is the AS number to use for the local end of the session.

--- a/config/all-in-one/frr-k8s.yaml
+++ b/config/all-in-one/frr-k8s.yaml
@@ -581,6 +581,37 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
+                              allowAsIn:
+                                description: |-
+                                  AllowAsIn controls whether routes with the local AS number in the AS path
+                                  are accepted from this neighbor for the enabled address families.
+                                  This is useful in hub-and-spoke or route-leaking topologies where the
+                                  same AS number may appear multiple times in the path.
+                                  Possible values:
+                                  - "" (empty, default): routes with the local AS in the path are rejected.
+                                    Does not reject other AllowAsIn values targeting the same neighbor.
+                                  - "none": routes with the local AS in the path are rejected.
+                                    Rejects other AllowAsIn values targeting the same neighbor.
+                                  - "origin": routes are accepted only if the local AS appears as the origin (last AS in the path).
+                                  - "1"-"10": routes are accepted with up to this many occurrences of the local AS in the path.
+                                  When multiple configurations target the same neighbor, any combination of
+                                  values resolves to the least restrictive, except "none" which rejects
+                                  all other values.
+                                enum:
+                                - ""
+                                - none
+                                - origin
+                                - "1"
+                                - "2"
+                                - "3"
+                                - "4"
+                                - "5"
+                                - "6"
+                                - "7"
+                                - "8"
+                                - "9"
+                                - "10"
+                                type: string
                               asn:
                                 description: |-
                                   ASN is the AS number to use for the local end of the session.

--- a/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
+++ b/config/crd/bases/frrk8s.metallb.io_frrconfigurations.yaml
@@ -489,6 +489,37 @@ spec:
                                   type: string
                                 maxItems: 2
                                 type: array
+                              allowAsIn:
+                                description: |-
+                                  AllowAsIn controls whether routes with the local AS number in the AS path
+                                  are accepted from this neighbor for the enabled address families.
+                                  This is useful in hub-and-spoke or route-leaking topologies where the
+                                  same AS number may appear multiple times in the path.
+                                  Possible values:
+                                  - "" (empty, default): routes with the local AS in the path are rejected.
+                                    Does not reject other AllowAsIn values targeting the same neighbor.
+                                  - "none": routes with the local AS in the path are rejected.
+                                    Rejects other AllowAsIn values targeting the same neighbor.
+                                  - "origin": routes are accepted only if the local AS appears as the origin (last AS in the path).
+                                  - "1"-"10": routes are accepted with up to this many occurrences of the local AS in the path.
+                                  When multiple configurations target the same neighbor, any combination of
+                                  values resolves to the least restrictive, except "none" which rejects
+                                  all other values.
+                                enum:
+                                - ""
+                                - none
+                                - origin
+                                - "1"
+                                - "2"
+                                - "3"
+                                - "4"
+                                - "5"
+                                - "6"
+                                - "7"
+                                - "8"
+                                - "9"
+                                - "10"
+                                type: string
                               asn:
                                 description: |-
                                   ASN is the AS number to use for the local end of the session.

--- a/e2etests/pkg/config/from_containers.go
+++ b/e2etests/pkg/config/from_containers.go
@@ -114,6 +114,30 @@ func EnableReceiveAllowAll(pc *PeersConfig) {
 	}
 }
 
+func EnableAllowAsIn(mode frrk8sv1beta1.AllowAsInMode) func(*PeersConfig) {
+	return func(pc *PeersConfig) {
+		t := pc.PeersV4
+		for i := 0; i < len(t); i++ {
+			t[i].Neigh.AllowAsIn = mode
+		}
+		t = pc.PeersV6
+		for i := 0; i < len(t); i++ {
+			t[i].Neigh.AllowAsIn = mode
+		}
+	}
+}
+
+func EnableDualStackAddressFamily(pc *PeersConfig) {
+	t := pc.PeersV4
+	for i := 0; i < len(t); i++ {
+		t[i].Neigh.DualStackAddressFamily = true
+	}
+	t = pc.PeersV6
+	for i := 0; i < len(t); i++ {
+		t[i].Neigh.DualStackAddressFamily = true
+	}
+}
+
 func EnableAllowAll(pc *PeersConfig) {
 	t := pc.PeersV4
 	for i := 0; i < len(t); i++ {

--- a/e2etests/pkg/frr/evpn.go
+++ b/e2etests/pkg/frr/evpn.go
@@ -24,6 +24,7 @@ type EVPNConfig struct {
 	L3VNI           uint32
 	L3VRF           string
 	AdvertiseFamily ipfamily.Family
+	PrependASN      uint32
 }
 
 // PairWithNodesForEVPN generates a BGP configuration with EVPN support for all
@@ -45,8 +46,9 @@ func PairWithNodesForEVPN(c *frrcontainer.FRR, cs clientset.Interface, cfg EVPNC
 	}
 
 	data := evpnTemplateData{
-		RouterASN: c.RouterConfig.ASN,
-		Neighbors: neighbors,
+		RouterASN:  c.RouterConfig.ASN,
+		Neighbors:  neighbors,
+		PrependASN: cfg.PrependASN,
 	}
 
 	if cfg.L2VNI > 0 {
@@ -83,6 +85,7 @@ func PairWithNodesForEVPN(c *frrcontainer.FRR, cs clientset.Interface, cfg EVPNC
 	}
 
 	fullConfig := insertBeforeRouterBGP(baseConfig, vrfPreamble) + evpnConfig
+
 	if err := c.UpdateConfigFile(fullConfig); err != nil {
 		return fmt.Errorf("writing BGP config: %w", err)
 	}
@@ -91,10 +94,11 @@ func PairWithNodesForEVPN(c *frrcontainer.FRR, cs clientset.Interface, cfg EVPNC
 }
 
 type evpnTemplateData struct {
-	RouterASN uint32
-	Neighbors []string
-	L2VNI     *evpnL2VNIData
-	L3VNI     *evpnL3VNIData
+	RouterASN  uint32
+	Neighbors  []string
+	L2VNI      *evpnL2VNIData
+	L3VNI      *evpnL3VNIData
+	PrependASN uint32
 }
 
 type evpnL2VNIData struct {
@@ -120,10 +124,20 @@ type evpnL3VNIData struct {
 // to the base BGP config. The VRF definition is handled separately by
 // evpnVRFTemplate because vtysh --mark requires it before any router bgp block.
 const evpnConfigTemplate = `
+{{- if gt .PrependASN 0 }}
+route-map PREPEND-ASN permit 10
+  set as-path prepend {{ .PrependASN }}
+!
+{{- end }}
 router bgp {{ .RouterASN }}
   address-family l2vpn evpn
   {{- range .Neighbors }}
     neighbor {{ . }} activate
+  {{- end }}
+  {{- if gt .PrependASN 0 }}
+  {{- range .Neighbors }}
+    neighbor {{ . }} route-map PREPEND-ASN out
+  {{- end }}
   {{- end }}
     advertise-all-vni
   {{- if .L2VNI }}

--- a/e2etests/pkg/frr/prepend_asn.go
+++ b/e2etests/pkg/frr/prepend_asn.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package frr
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"text/template"
+
+	"github.com/metallb/frrk8stests/pkg/k8s"
+	frrconfig "go.universe.tf/e2etest/pkg/frr/config"
+	frrcontainer "go.universe.tf/e2etest/pkg/frr/container"
+	"go.universe.tf/e2etest/pkg/ipfamily"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+type prependASNConfig struct {
+	RouterASN  uint32
+	PrependASN uint32
+	Neighbors  []string
+	HasV4      bool
+	HasV6      bool
+}
+
+const prependASNConfigTemplate = `
+route-map PREPEND-ASN permit 10
+  set as-path prepend {{ .PrependASN }}
+!
+router bgp {{ .RouterASN }}
+{{- if .HasV4 }}
+  address-family ipv4 unicast
+{{- range .Neighbors }}
+    neighbor {{ . }} route-map PREPEND-ASN out
+{{- end }}
+  exit-address-family
+{{- end }}
+{{- if .HasV6 }}
+  address-family ipv6 unicast
+{{- range .Neighbors }}
+    neighbor {{ . }} route-map PREPEND-ASN out
+{{- end }}
+  exit-address-family
+{{- end }}
+`
+
+var prependASNTmpl = template.Must(template.New("prependASN").Parse(prependASNConfigTemplate))
+
+func appendPrependASNConfig(baseConfig string, cfg prependASNConfig) (string, error) {
+	if cfg.PrependASN == 0 {
+		return baseConfig, nil
+	}
+	var buf bytes.Buffer
+	if err := prependASNTmpl.Execute(&buf, cfg); err != nil {
+		return "", fmt.Errorf("rendering prepend ASN config: %w", err)
+	}
+	return baseConfig + buf.String(), nil
+}
+
+// PairWithNodesWithPrependASN generates a BGP configuration that advertises
+// prefixes with a prepended ASN in the AS path, and writes it to the container.
+// Modifiers are applied to a copy of the container to set NeighborConfig fields
+// (e.g. ToAdvertiseV4/V6) before generating the config, following the same
+// pattern as PairWithNodes.
+func PairWithNodesWithPrependASN(c *frrcontainer.FRR, cs clientset.Interface, prependASN uint32, peerFamily ipfamily.Family, modifiers ...func(c *frrcontainer.FRR)) error {
+	config := *c
+	for _, m := range modifiers {
+		m(&config)
+	}
+
+	baseConfig, err := frrconfig.BGPPeersForAllNodes(cs, config.NeighborConfig, config.RouterConfig, peerFamily, frrconfig.MultiProtocolEnabled)
+	if err != nil {
+		return fmt.Errorf("generating base BGP config: %w", err)
+	}
+
+	nodes, err := cs.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("listing nodes: %w", err)
+	}
+
+	neighbors, err := k8s.NodeIPsForFamily(nodes.Items, peerFamily)
+	if err != nil {
+		return fmt.Errorf("getting node IPs: %w", err)
+	}
+
+	cfg := prependASNConfig{
+		RouterASN:  config.RouterConfig.ASN,
+		PrependASN: prependASN,
+		Neighbors:  neighbors,
+		HasV4:      len(config.NeighborConfig.ToAdvertiseV4) > 0,
+		HasV6:      len(config.NeighborConfig.ToAdvertiseV6) > 0,
+	}
+
+	fullConfig, err := appendPrependASNConfig(baseConfig, cfg)
+	if err != nil {
+		return fmt.Errorf("appending prepend ASN config: %w", err)
+	}
+
+	if err := c.UpdateConfigFile(fullConfig); err != nil {
+		return fmt.Errorf("writing BGP config: %w", err)
+	}
+
+	return nil
+}

--- a/e2etests/tests/allowas_in.go
+++ b/e2etests/tests/allowas_in.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier:Apache-2.0
+
+package tests
+
+import (
+	"github.com/onsi/ginkgo/v2"
+
+	frrk8sv1beta1 "github.com/metallb/frr-k8s/api/v1beta1"
+	"github.com/metallb/frrk8stests/pkg/config"
+	"github.com/metallb/frrk8stests/pkg/dump"
+	"github.com/metallb/frrk8stests/pkg/frr"
+	"github.com/metallb/frrk8stests/pkg/infra"
+	"github.com/metallb/frrk8stests/pkg/k8s"
+	"github.com/metallb/frrk8stests/pkg/k8sclient"
+	. "github.com/onsi/gomega"
+	frrconfig "go.universe.tf/e2etest/pkg/frr/config"
+	frrcontainer "go.universe.tf/e2etest/pkg/frr/container"
+	"go.universe.tf/e2etest/pkg/ipfamily"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+)
+
+var _ = ginkgo.Describe("AllowAsIn", func() {
+	var cs clientset.Interface
+
+	defer ginkgo.GinkgoRecover()
+	updater, err := config.NewUpdater()
+	Expect(err).NotTo(HaveOccurred())
+	reporter := dump.NewK8sReporter(k8s.FRRK8sNamespace)
+
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentSpecReport().Failed() {
+			testName := ginkgo.CurrentSpecReport().LeafNodeText
+			dump.K8sInfo(testName, reporter)
+			dump.BGPInfo(testName, infra.FRRContainers, cs)
+		}
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Clearing any previous configuration")
+
+		for _, c := range infra.FRRContainers {
+			err := c.UpdateConfigFile(frrconfig.Empty)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		err := updater.Clean()
+		Expect(err).NotTo(HaveOccurred())
+
+		cs = k8sclient.New()
+	})
+
+	type params struct {
+		ipFamily     ipfamily.Family
+		allowAsIn    frrk8sv1beta1.AllowAsInMode
+		advertiseV4  []string
+		advertiseV6  []string
+		expectRoutes bool
+	}
+
+	ginkgo.DescribeTable("routes with local AS in path", func(p params) {
+		ebgpContainer := infra.FindContainer("ebgp-single-hop")
+		Expect(ebgpContainer).NotTo(BeNil(), "ebgp-single-hop container not found")
+
+		frrs := []*frrcontainer.FRR{ebgpContainer}
+		peersConfig := config.PeersForContainers(frrs, p.ipFamily, config.EnableReceiveAllowAll, config.EnableAllowAsIn(p.allowAsIn), config.EnableDualStackAddressFamily)
+		neighbors := config.NeighborsFromPeers(peersConfig.PeersV4, peersConfig.PeersV6)
+
+		frrCfg := frrk8sv1beta1.FRRConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-allowasin",
+				Namespace: k8s.FRRK8sNamespace,
+			},
+			Spec: frrk8sv1beta1.FRRConfigurationSpec{
+				BGP: frrk8sv1beta1.BGPConfig{
+					Routers: []frrk8sv1beta1.Router{
+						{
+							ASN:       infra.FRRK8sASN,
+							Neighbors: neighbors,
+						},
+					},
+				},
+			},
+		}
+
+		ginkgo.By("Pairing external FRR with nodes using AS path prepend")
+		err := frr.PairWithNodesWithPrependASN(ebgpContainer, cs, infra.FRRK8sASN, p.ipFamily,
+			func(c *frrcontainer.FRR) {
+				c.NeighborConfig.ToAdvertiseV4 = p.advertiseV4
+				c.NeighborConfig.ToAdvertiseV6 = p.advertiseV6
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Applying FRRConfiguration")
+		err = updater.Update(peersConfig.Secrets, frrCfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		k8sNodes, err := k8s.Nodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+
+		ginkgo.By("Validating BGP sessions are established")
+		ValidateFRRPeeredWithNodes(k8sNodes, ebgpContainer, p.ipFamily)
+
+		pods, err := k8s.FRRK8sPods(cs)
+		Expect(err).NotTo(HaveOccurred())
+
+		allPrefixes := append(p.advertiseV4, p.advertiseV6...)
+		if p.expectRoutes {
+			ginkgo.By("Validating nodes received the routes with local AS in path")
+			ValidateNodesHaveRoutes(pods, *ebgpContainer, allPrefixes...)
+		} else {
+			ginkgo.By("Validating nodes rejected the routes with local AS in path")
+			ValidateNodesDoNotHaveRoutes(pods, *ebgpContainer, allPrefixes...)
+		}
+	},
+		ginkgo.Entry("should be accepted with AllowAsIn origin", params{
+			ipFamily:     ipfamily.DualStack,
+			allowAsIn:    frrk8sv1beta1.AllowAsInOrigin,
+			advertiseV4:  []string{"192.168.100.0/24"},
+			advertiseV6:  []string{"fc00:100::/64"},
+			expectRoutes: true,
+		}),
+		ginkgo.Entry("should be rejected without AllowAsIn", params{
+			ipFamily:     ipfamily.DualStack,
+			advertiseV4:  []string{"192.168.100.0/24"},
+			advertiseV6:  []string{"fc00:100::/64"},
+			expectRoutes: false,
+		}),
+	)
+})

--- a/e2etests/tests/evpn.go
+++ b/e2etests/tests/evpn.go
@@ -60,333 +60,210 @@ var evpnL3ConfigTemplate = infra.EVPNConfig{
 	Vxlan:           evpnVxlan,
 }
 
-var _ = ginkgo.DescribeTableSubtree("EVPN",
-	func(peerFamily ipfamily.Family, advertiseFamily ipfamily.Family) {
-		var (
-			cs               clientset.Interface
-			nodes            []corev1.Node
-			evpnCfg          infra.EVPNConfig
-			evpnInfra        *infra.EVPN
-			evpnFRRContainer *frrcontainer.FRR
-		)
+var _ = ginkgo.Describe("EVPN sessions", func() {
+	var (
+		cs               clientset.Interface
+		nodes            []corev1.Node
+		evpnCfg          infra.EVPNConfig
+		evpnInfra        *infra.EVPN
+		evpnFRRContainer *frrcontainer.FRR
+	)
 
-		defer ginkgo.GinkgoRecover()
-		updater, err := config.NewUpdater()
+	defer ginkgo.GinkgoRecover()
+	updater, err := config.NewUpdater()
+	Expect(err).NotTo(HaveOccurred())
+	reporter := dump.NewK8sReporter(k8s.FRRK8sNamespace)
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Clearing any previous configuration")
+		for _, c := range infra.FRRContainers {
+			err := c.UpdateConfigFile(frrconfig.Empty)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		err := updater.Clean()
 		Expect(err).NotTo(HaveOccurred())
-		reporter := dump.NewK8sReporter(k8s.FRRK8sNamespace)
 
-		ginkgo.BeforeEach(func() {
-			ginkgo.By("Clearing any previous configuration")
-			for _, c := range infra.FRRContainers {
-				err := c.UpdateConfigFile(frrconfig.Empty)
-				Expect(err).NotTo(HaveOccurred())
-			}
-			err := updater.Clean()
-			Expect(err).NotTo(HaveOccurred())
+		// Workaround for https://github.com/FRRouting/frr/issues/22060:
+		// frr-reload.py crashes when a config transition both removes route-maps
+		// and adds a new address-family. Wait for the clean config to be applied
+		// before the EVPN config, avoiding the two being merged by the debouncer.
+		time.Sleep(5 * time.Second)
 
-			// Workaround for https://github.com/FRRouting/frr/issues/22060:
-			// frr-reload.py crashes when a config transition both removes route-maps
-			// and adds a new address-family. Wait for the clean config to be applied
-			// before the EVPN config, avoiding the two being merged by the debouncer.
-			time.Sleep(5 * time.Second)
+		cs = k8sclient.New()
+		nodes, err = k8s.Nodes(cs)
+		Expect(err).NotTo(HaveOccurred())
+	})
 
-			evpnFRRContainer = infra.FindContainer(evpnFRRContainerName)
-			Expect(evpnFRRContainer).NotTo(BeNil(), "%s container not found in FRRContainers", evpnFRRContainerName)
-
-			cs = k8sclient.New()
-			nodes, err = k8s.Nodes(cs)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		ginkgo.AfterEach(func() {
-			if ginkgo.CurrentSpecReport().Failed() {
-				testName := ginkgo.CurrentSpecReport().LeafNodeText
-				dump.K8sInfo(testName, reporter)
-				dump.BGPInfo(testName, infra.FRRContainers, cs)
-			}
-			err := infra.CleanupEVPN(cs, evpnFRRContainer, evpnCfg)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		setupEVPN := func(tmpl infra.EVPNConfig) config.PeersConfig {
-			ginkgo.GinkgoHelper()
-
-			evpnCfg = tmpl
-			switch advertiseFamily {
-			case ipfamily.IPv4:
-				evpnCfg.L2IPv6Fmt = ""
-				evpnCfg.L3IPv6PrefixFmt = ""
-			case ipfamily.IPv6:
-				evpnCfg.L2IPFmt = ""
-				evpnCfg.L3PrefixFmt = ""
-			}
-
-			ginkgo.By("Setting up EVPN networking infrastructure")
-			var err error
-			evpnInfra, err = infra.SetupEVPN(cs, evpnFRRContainer, evpnCfg)
-			Expect(err).NotTo(HaveOccurred())
-
-			ginkgo.By("Pairing external FRR with nodes (EVPN)")
-			evpnCfg := frr.EVPNConfig{
-				L2VNI:           evpnCfg.L2VNI,
-				L3VNI:           evpnCfg.L3VNI,
-				L3VRF:           evpnCfg.L3VRF,
-				AdvertiseFamily: advertiseFamily,
-			}
-			err = frr.PairWithNodesForEVPN(evpnFRRContainer, cs, evpnCfg, peerFamily)
-			Expect(err).NotTo(HaveOccurred())
-			return config.PeersForContainers([]*frrcontainer.FRR{evpnFRRContainer}, peerFamily)
+	ginkgo.AfterEach(func() {
+		if ginkgo.CurrentSpecReport().Failed() {
+			testName := ginkgo.CurrentSpecReport().LeafNodeText
+			dump.K8sInfo(testName, reporter)
+			dump.BGPInfo(testName, infra.FRRContainers, cs)
 		}
+		err := infra.CleanupEVPN(cs, evpnFRRContainer, evpnCfg)
+		Expect(err).NotTo(HaveOccurred())
+	})
 
-		neighborsWithEVPN := func(peersConfig config.PeersConfig) []frrk8sv1beta1.Neighbor {
-			neighbors := config.NeighborsFromPeers(peersConfig.PeersV4, peersConfig.PeersV6)
-			for i := range neighbors {
-				neighbors[i].AddressFamilies = []frrk8sv1beta1.AddressFamily{"unicast", "evpn"}
-			}
-			return neighbors
-		}
-
-		// validateL2VNI validates L2 VNI EVPN state: sessions, VNI visibility,
-		// type-2 routes, and data path connectivity.
-		validateL2VNI := func() {
-			ginkgo.GinkgoHelper()
-			ginkgo.By("Validating BGP sessions are established")
-			ValidateFRRPeeredWithNodes(nodes, evpnFRRContainer, peerFamily)
-
-			ginkgo.By("Validating EVPN address family is active on frr-k8s pods")
-			pods, err := k8s.FRRK8sPods(cs)
-			Expect(err).NotTo(HaveOccurred())
-
-			for _, pod := range pods {
-				for _, peerIP := range evpnFRRContainer.AddressesForFamily(peerFamily) {
-					Eventually(func() error {
-						return frr.ForPod(pod).HasEVPNNeighbor(peerIP)
-					}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
-						"EVPN address family not active on pod %s for peer %s", pod.Name, peerIP)
-				}
-			}
-
-			ginkgo.By("Validating L2 VNI is visible in EVPN state")
-			for _, pod := range pods {
-				Eventually(func() error {
-					return frr.ForPod(pod).HasEVPNVNI(evpnCfg.L2VNI)
-				}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
-					"L2 VNI %d not visible on pod %s", evpnCfg.L2VNI, pod.Name)
-			}
-
-			ginkgo.By("Collecting expected type-2 routes")
-			expectedType2, err := expectedL2VNIRoutes(pods)
-			Expect(err).NotTo(HaveOccurred())
-
-			ginkgo.By("Validating EVPN type-2 routes are exchanged")
-			Eventually(func() error {
-				return frr.ForContainer(evpnFRRContainer).HasEVPNType2Routes(expectedType2)
-			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
-				"Type-2 routes not found on external FRR")
-
-			targetIPs := map[string]string{}
-			for _, node := range nodes {
-				for _, ip := range evpnInfra.L2IPForFamily(node.Name, advertiseFamily) {
-					targetIPs[ip] = node.Name
-				}
-			}
-
-			ginkgo.By("Validating L2 data path from external FRR to nodes")
-			for targetIP, node := range targetIPs {
-				Eventually(func() error {
-					return ping(evpnFRRContainer, targetIP)
-				}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
-					"ping from external FRR to node %s (%s) failed", node, targetIP, evpnCfg.L3VRF)
-			}
-		}
-
-		// validateL3VNI validates L3 VNI EVPN state: sessions, type-5 routes,
-		// and data path connectivity.
-		validateL3VNI := func() {
-			ginkgo.GinkgoHelper()
-			ginkgo.By("Validating BGP sessions are established")
-			ValidateFRRPeeredWithNodes(nodes, evpnFRRContainer, peerFamily)
-
-			ginkgo.By("Validating EVPN address family is active on frr-k8s pods")
-			pods, err := k8s.FRRK8sPods(cs)
-			Expect(err).NotTo(HaveOccurred())
-
-			for _, pod := range pods {
-				for _, peerIP := range evpnFRRContainer.AddressesForFamily(peerFamily) {
-					Eventually(func() error {
-						return frr.ForPod(pod).HasEVPNNeighbor(peerIP)
-					}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
-						"EVPN address family not active on pod %s for peer %s", pod.Name, peerIP)
-				}
-			}
-
-			expectedRoutes := map[string]string{}
-			targetIPs := map[string]string{}
-			for _, node := range nodes {
-				// only IPv4 supported as next hop VTEP for now
-				nodeIP, err := k8s.NodeIPForFamily(node, ipfamily.IPv4)
-				Expect(err).NotTo(HaveOccurred())
-				for _, prefix := range evpnInfra.L3PrefixForFamily(node.Name, advertiseFamily) {
-					expectedRoutes[prefix] = nodeIP
-				}
-				for _, ip := range evpnInfra.L3IPForFamily(node.Name, advertiseFamily) {
-					targetIPs[ip] = node.Name
-				}
-			}
-
-			ginkgo.By("Validating EVPN type-5 routes are received on external FRR")
-			Eventually(func() error {
-				return frr.ForContainer(evpnFRRContainer).HasEVPNType5Routes(expectedRoutes)
-			}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
-
-			ginkgo.By("Validating L3 data path from external FRR to nodes via VRF")
-			for targetIP, node := range targetIPs {
-				Eventually(func() error {
-					return pingVRF(evpnFRRContainer, evpnCfg.L3VRF, targetIP)
-				}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
-					"ping from external FRR to node %s (%s) via VRF %s failed", node, targetIP, evpnCfg.L3VRF)
-			}
-		}
-
-		ginkgo.Context("L2 VNI", func() {
-			ginkgo.It("should establish EVPN session and exchange L2 VNI routes", func() {
-				peersConfig := setupEVPN(evpnL2ConfigTemplate)
-
-				ginkgo.By("Building FRRConfiguration with EVPN L2 VNI")
-				neighbors := neighborsWithEVPN(peersConfig)
-
-				frrCfg := frrk8sv1beta1.FRRConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-evpn-l2",
-						Namespace: k8s.FRRK8sNamespace,
-					},
-					Spec: frrk8sv1beta1.FRRConfigurationSpec{
-						BGP: frrk8sv1beta1.BGPConfig{
-							Routers: []frrk8sv1beta1.Router{
-								{
-									ASN:       infra.FRRK8sASN,
-									Neighbors: neighbors,
-									EVPN: &frrk8sv1beta1.EVPNConfig{
-										AdvertiseVNIs: ptr.To(frrk8sv1beta1.VNIAdvertisementAll),
-										L2VNIs: []frrk8sv1beta1.L2VNI{
-											{
-												VNI: evpnCfg.L2VNI,
-												VNIProperties: frrk8sv1beta1.VNIProperties{
-													RD: frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI)),
-													ImportRTs: []frrk8sv1beta1.ImportRouteTarget{
-														frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI)),
-														frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", evpnFRRContainer.RouterConfig.ASN, evpnCfg.L2VNI)),
-													},
-													ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI))},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-
-				ginkgo.By("Applying FRRConfiguration")
-				err = updater.Update(peersConfig.Secrets, frrCfg)
-				Expect(err).NotTo(HaveOccurred())
-
-				validateL2VNI()
+	ginkgo.DescribeTableSubtree("when exchanging routes and coursing traffic",
+		func(peerFamily ipfamily.Family, advertiseFamily ipfamily.Family) {
+			ginkgo.BeforeEach(func() {
+				evpnFRRContainer = infra.FindContainer(evpnFRRContainerName)
+				Expect(evpnFRRContainer).NotTo(BeNil(), "%s container not found in FRRContainers", evpnFRRContainerName)
 			})
 
-			ginkgo.It("should work with L2 VNI config split across multiple FRRConfigurations", func() {
-				peersConfig := setupEVPN(evpnL2ConfigTemplate)
+			setupEVPN := func(tmpl infra.EVPNConfig) config.PeersConfig {
+				ginkgo.GinkgoHelper()
 
-				ginkgo.By("Building split FRRConfigurations: one with local ASN RT, one with external ASN RT")
-				neighbors := neighborsWithEVPN(peersConfig)
-
-				// First config: neighbors, advertiseVNIs, and L2VNI with local ASN import RT.
-				cfgLocal := frrk8sv1beta1.FRRConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-evpn-l2-local",
-						Namespace: k8s.FRRK8sNamespace,
-					},
-					Spec: frrk8sv1beta1.FRRConfigurationSpec{
-						BGP: frrk8sv1beta1.BGPConfig{
-							Routers: []frrk8sv1beta1.Router{
-								{
-									ASN:       infra.FRRK8sASN,
-									Neighbors: neighbors,
-									EVPN: &frrk8sv1beta1.EVPNConfig{
-										AdvertiseVNIs: ptr.To(frrk8sv1beta1.VNIAdvertisementAll),
-										L2VNIs: []frrk8sv1beta1.L2VNI{
-											{
-												VNI: evpnCfg.L2VNI,
-												VNIProperties: frrk8sv1beta1.VNIProperties{
-													RD:        frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI)),
-													ImportRTs: []frrk8sv1beta1.ImportRouteTarget{frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI))},
-													ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI))},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
+				evpnCfg = tmpl
+				switch advertiseFamily {
+				case ipfamily.IPv4:
+					evpnCfg.L2IPv6Fmt = ""
+					evpnCfg.L3IPv6PrefixFmt = ""
+				case ipfamily.IPv6:
+					evpnCfg.L2IPFmt = ""
+					evpnCfg.L3PrefixFmt = ""
 				}
 
-				// Second config: same L2VNI with external ASN import RT (merged with first).
-				cfgExternal := frrk8sv1beta1.FRRConfiguration{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-evpn-l2-external",
-						Namespace: k8s.FRRK8sNamespace,
-					},
-					Spec: frrk8sv1beta1.FRRConfigurationSpec{
-						BGP: frrk8sv1beta1.BGPConfig{
-							Routers: []frrk8sv1beta1.Router{
-								{
-									ASN: infra.FRRK8sASN,
-									EVPN: &frrk8sv1beta1.EVPNConfig{
-										AdvertiseVNIs: ptr.To(frrk8sv1beta1.VNIAdvertisementAll),
-										L2VNIs: []frrk8sv1beta1.L2VNI{
-											{
-												VNI: evpnCfg.L2VNI,
-												VNIProperties: frrk8sv1beta1.VNIProperties{
-													RD:        frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI)),
-													ImportRTs: []frrk8sv1beta1.ImportRouteTarget{frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", evpnFRRContainer.RouterConfig.ASN, evpnCfg.L2VNI))},
-													ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI))},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-
-				ginkgo.By("Applying split FRRConfigurations")
-				err = updater.Update(peersConfig.Secrets, cfgLocal, cfgExternal)
+				ginkgo.By("Setting up EVPN networking infrastructure")
+				var err error
+				evpnInfra, err = infra.SetupEVPN(cs, evpnFRRContainer, evpnCfg)
 				Expect(err).NotTo(HaveOccurred())
 
-				validateL2VNI()
-			})
-		})
+				ginkgo.By("Pairing external FRR with nodes (EVPN)")
+				evpnCfg := frr.EVPNConfig{
+					L2VNI:           evpnCfg.L2VNI,
+					L3VNI:           evpnCfg.L3VNI,
+					L3VRF:           evpnCfg.L3VRF,
+					AdvertiseFamily: advertiseFamily,
+				}
+				err = frr.PairWithNodesForEVPN(evpnFRRContainer, cs, evpnCfg, peerFamily)
+				Expect(err).NotTo(HaveOccurred())
+				return config.PeersForContainers([]*frrcontainer.FRR{evpnFRRContainer}, peerFamily)
+			}
 
-		ginkgo.Context("L3 VNI", func() {
-			// l3VNIConfigs builds per-node FRRConfigurations with both the default-VRF
-			// router (neighbors + advertiseVNIs) and the VRF router (L3VNI).
-			l3VNIConfigs := func(neighbors []frrk8sv1beta1.Neighbor) []frrk8sv1beta1.FRRConfiguration {
-				var cfgs []frrk8sv1beta1.FRRConfiguration
+			neighborsWithEVPN := func(peersConfig config.PeersConfig) []frrk8sv1beta1.Neighbor {
+				neighbors := config.NeighborsFromPeers(peersConfig.PeersV4, peersConfig.PeersV6)
+				for i := range neighbors {
+					neighbors[i].AddressFamilies = []frrk8sv1beta1.AddressFamily{"unicast", "evpn"}
+				}
+				return neighbors
+			}
+
+			// validateL2VNI validates L2 VNI EVPN state: sessions, VNI visibility,
+			// type-2 routes, and data path connectivity.
+			validateL2VNI := func() {
+				ginkgo.GinkgoHelper()
+				ginkgo.By("Validating BGP sessions are established")
+				ValidateFRRPeeredWithNodes(nodes, evpnFRRContainer, peerFamily)
+
+				ginkgo.By("Validating EVPN address family is active on frr-k8s pods")
+				pods, err := k8s.FRRK8sPods(cs)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, pod := range pods {
+					for _, peerIP := range evpnFRRContainer.AddressesForFamily(peerFamily) {
+						Eventually(func() error {
+							return frr.ForPod(pod).HasEVPNNeighbor(peerIP)
+						}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
+							"EVPN address family not active on pod %s for peer %s", pod.Name, peerIP)
+					}
+				}
+
+				ginkgo.By("Validating L2 VNI is visible in EVPN state")
+				for _, pod := range pods {
+					Eventually(func() error {
+						return frr.ForPod(pod).HasEVPNVNI(evpnCfg.L2VNI)
+					}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
+						"L2 VNI %d not visible on pod %s", evpnCfg.L2VNI, pod.Name)
+				}
+
+				ginkgo.By("Collecting expected type-2 routes")
+				expectedType2, err := expectedL2VNIRoutes(pods)
+				Expect(err).NotTo(HaveOccurred())
+
+				ginkgo.By("Validating EVPN type-2 routes are exchanged")
+				Eventually(func() error {
+					return frr.ForContainer(evpnFRRContainer).HasEVPNType2Routes(expectedType2)
+				}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
+					"Type-2 routes not found on external FRR")
+
+				targetIPs := map[string]string{}
 				for _, node := range nodes {
-					cfgs = append(cfgs, frrk8sv1beta1.FRRConfiguration{
+					for _, ip := range evpnInfra.L2IPForFamily(node.Name, advertiseFamily) {
+						targetIPs[ip] = node.Name
+					}
+				}
+
+				ginkgo.By("Validating L2 data path from external FRR to nodes")
+				for targetIP, node := range targetIPs {
+					Eventually(func() error {
+						return ping(evpnFRRContainer, targetIP)
+					}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
+						"ping from external FRR to node %s (%s) failed", node, targetIP)
+				}
+			}
+
+			// validateL3VNI validates L3 VNI EVPN state: sessions, type-5 routes,
+			// and data path connectivity.
+			validateL3VNI := func() {
+				ginkgo.GinkgoHelper()
+				ginkgo.By("Validating BGP sessions are established")
+				ValidateFRRPeeredWithNodes(nodes, evpnFRRContainer, peerFamily)
+
+				ginkgo.By("Validating EVPN address family is active on frr-k8s pods")
+				pods, err := k8s.FRRK8sPods(cs)
+				Expect(err).NotTo(HaveOccurred())
+
+				for _, pod := range pods {
+					for _, peerIP := range evpnFRRContainer.AddressesForFamily(peerFamily) {
+						Eventually(func() error {
+							return frr.ForPod(pod).HasEVPNNeighbor(peerIP)
+						}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
+							"EVPN address family not active on pod %s for peer %s", pod.Name, peerIP)
+					}
+				}
+
+				expectedRoutes := map[string]string{}
+				targetIPs := map[string]string{}
+				for _, node := range nodes {
+					// only IPv4 supported as next hop VTEP for now
+					nodeIP, err := k8s.NodeIPForFamily(node, ipfamily.IPv4)
+					Expect(err).NotTo(HaveOccurred())
+					for _, prefix := range evpnInfra.L3PrefixForFamily(node.Name, advertiseFamily) {
+						expectedRoutes[prefix] = nodeIP
+					}
+					for _, ip := range evpnInfra.L3IPForFamily(node.Name, advertiseFamily) {
+						targetIPs[ip] = node.Name
+					}
+				}
+
+				ginkgo.By("Validating EVPN type-5 routes are received on external FRR")
+				Eventually(func() error {
+					return frr.ForContainer(evpnFRRContainer).HasEVPNType5Routes(expectedRoutes)
+				}, 30*time.Second, time.Second).ShouldNot(HaveOccurred())
+
+				ginkgo.By("Validating L3 data path from external FRR to nodes via VRF")
+				for targetIP, node := range targetIPs {
+					Eventually(func() error {
+						return pingVRF(evpnFRRContainer, evpnCfg.L3VRF, targetIP)
+					}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
+						"ping from external FRR to node %s (%s) via VRF %s failed", node, targetIP, evpnCfg.L3VRF)
+				}
+			}
+
+			ginkgo.Context("with L2 VNI in use", func() {
+				ginkgo.It("should establish EVPN session and exchange Type-2 routes", func() {
+					peersConfig := setupEVPN(evpnL2ConfigTemplate)
+
+					ginkgo.By("Building FRRConfiguration with EVPN L2 VNI")
+					neighbors := neighborsWithEVPN(peersConfig)
+
+					frrCfg := frrk8sv1beta1.FRRConfiguration{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      fmt.Sprintf("test-evpn-l3-%s", node.Name),
+							Name:      "test-evpn-l2",
 							Namespace: k8s.FRRK8sNamespace,
 						},
 						Spec: frrk8sv1beta1.FRRConfigurationSpec{
-							NodeSelector: metav1.LabelSelector{
-								MatchLabels: map[string]string{
-									"kubernetes.io/hostname": node.Name,
-								},
-							},
 							BGP: frrk8sv1beta1.BGPConfig{
 								Routers: []frrk8sv1beta1.Router{
 									{
@@ -394,99 +271,349 @@ var _ = ginkgo.DescribeTableSubtree("EVPN",
 										Neighbors: neighbors,
 										EVPN: &frrk8sv1beta1.EVPNConfig{
 											AdvertiseVNIs: ptr.To(frrk8sv1beta1.VNIAdvertisementAll),
-										},
-									},
-									{
-										ASN:      infra.FRRK8sASN,
-										VRF:      evpnCfg.L3VRF,
-										Prefixes: evpnInfra.L3PrefixForFamily(node.Name, advertiseFamily),
-										EVPN: &frrk8sv1beta1.EVPNConfig{
-											L3VNI: &frrk8sv1beta1.L3VNI{
-												VNI: evpnCfg.L3VNI,
-												VNIProperties: frrk8sv1beta1.VNIProperties{
-													RD: frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L3VNI)),
-													ImportRTs: []frrk8sv1beta1.ImportRouteTarget{
-														frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L3VNI)),
-														frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", evpnFRRContainer.RouterConfig.ASN, evpnCfg.L3VNI)),
+											L2VNIs: []frrk8sv1beta1.L2VNI{
+												{
+													VNI: evpnCfg.L2VNI,
+													VNIProperties: frrk8sv1beta1.VNIProperties{
+														RD: frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI)),
+														ImportRTs: []frrk8sv1beta1.ImportRouteTarget{
+															frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI)),
+															frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", evpnFRRContainer.RouterConfig.ASN, evpnCfg.L2VNI)),
+														},
+														ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI))},
 													},
-													ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L3VNI))},
 												},
-												AdvertisePrefixes: []frrk8sv1beta1.AdvertisePrefixType{"unicast"},
 											},
 										},
 									},
 								},
 							},
 						},
-					})
+					}
+
+					ginkgo.By("Applying FRRConfiguration")
+					err = updater.Update(peersConfig.Secrets, frrCfg)
+					Expect(err).NotTo(HaveOccurred())
+
+					validateL2VNI()
+				})
+
+				ginkgo.It("should establish EVPN session and exchange Type-2 routes with L2 VNI config split across multiple FRRConfigurations", func() {
+					peersConfig := setupEVPN(evpnL2ConfigTemplate)
+
+					ginkgo.By("Building split FRRConfigurations: one with local ASN RT, one with external ASN RT")
+					neighbors := neighborsWithEVPN(peersConfig)
+
+					// First config: neighbors, advertiseVNIs, and L2VNI with local ASN import RT.
+					cfgLocal := frrk8sv1beta1.FRRConfiguration{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-evpn-l2-local",
+							Namespace: k8s.FRRK8sNamespace,
+						},
+						Spec: frrk8sv1beta1.FRRConfigurationSpec{
+							BGP: frrk8sv1beta1.BGPConfig{
+								Routers: []frrk8sv1beta1.Router{
+									{
+										ASN:       infra.FRRK8sASN,
+										Neighbors: neighbors,
+										EVPN: &frrk8sv1beta1.EVPNConfig{
+											AdvertiseVNIs: ptr.To(frrk8sv1beta1.VNIAdvertisementAll),
+											L2VNIs: []frrk8sv1beta1.L2VNI{
+												{
+													VNI: evpnCfg.L2VNI,
+													VNIProperties: frrk8sv1beta1.VNIProperties{
+														RD:        frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI)),
+														ImportRTs: []frrk8sv1beta1.ImportRouteTarget{frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI))},
+														ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI))},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+
+					// Second config: same L2VNI with external ASN import RT (merged with first).
+					cfgExternal := frrk8sv1beta1.FRRConfiguration{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-evpn-l2-external",
+							Namespace: k8s.FRRK8sNamespace,
+						},
+						Spec: frrk8sv1beta1.FRRConfigurationSpec{
+							BGP: frrk8sv1beta1.BGPConfig{
+								Routers: []frrk8sv1beta1.Router{
+									{
+										ASN: infra.FRRK8sASN,
+										EVPN: &frrk8sv1beta1.EVPNConfig{
+											AdvertiseVNIs: ptr.To(frrk8sv1beta1.VNIAdvertisementAll),
+											L2VNIs: []frrk8sv1beta1.L2VNI{
+												{
+													VNI: evpnCfg.L2VNI,
+													VNIProperties: frrk8sv1beta1.VNIProperties{
+														RD:        frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI)),
+														ImportRTs: []frrk8sv1beta1.ImportRouteTarget{frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", evpnFRRContainer.RouterConfig.ASN, evpnCfg.L2VNI))},
+														ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L2VNI))},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					}
+
+					ginkgo.By("Applying split FRRConfigurations")
+					err = updater.Update(peersConfig.Secrets, cfgLocal, cfgExternal)
+					Expect(err).NotTo(HaveOccurred())
+
+					validateL2VNI()
+				})
+			})
+
+			ginkgo.Context("with L3 VNI in use", func() {
+				// l3VNIConfigs builds per-node FRRConfigurations with both the default-VRF
+				// router (neighbors + advertiseVNIs) and the VRF router (L3VNI).
+				l3VNIConfigs := func(neighbors []frrk8sv1beta1.Neighbor) []frrk8sv1beta1.FRRConfiguration {
+					var cfgs []frrk8sv1beta1.FRRConfiguration
+					for _, node := range nodes {
+						cfgs = append(cfgs, frrk8sv1beta1.FRRConfiguration{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      fmt.Sprintf("test-evpn-l3-%s", node.Name),
+								Namespace: k8s.FRRK8sNamespace,
+							},
+							Spec: frrk8sv1beta1.FRRConfigurationSpec{
+								NodeSelector: metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"kubernetes.io/hostname": node.Name,
+									},
+								},
+								BGP: frrk8sv1beta1.BGPConfig{
+									Routers: []frrk8sv1beta1.Router{
+										{
+											ASN:       infra.FRRK8sASN,
+											Neighbors: neighbors,
+											EVPN: &frrk8sv1beta1.EVPNConfig{
+												AdvertiseVNIs: ptr.To(frrk8sv1beta1.VNIAdvertisementAll),
+											},
+										},
+										{
+											ASN:      infra.FRRK8sASN,
+											VRF:      evpnCfg.L3VRF,
+											Prefixes: evpnInfra.L3PrefixForFamily(node.Name, advertiseFamily),
+											EVPN: &frrk8sv1beta1.EVPNConfig{
+												L3VNI: &frrk8sv1beta1.L3VNI{
+													VNI: evpnCfg.L3VNI,
+													VNIProperties: frrk8sv1beta1.VNIProperties{
+														RD: frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L3VNI)),
+														ImportRTs: []frrk8sv1beta1.ImportRouteTarget{
+															frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L3VNI)),
+															frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", evpnFRRContainer.RouterConfig.ASN, evpnCfg.L3VNI)),
+														},
+														ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnCfg.L3VNI))},
+													},
+													AdvertisePrefixes: []frrk8sv1beta1.AdvertisePrefixType{"unicast"},
+												},
+											},
+										},
+									},
+								},
+							},
+						})
+					}
+					return cfgs
 				}
-				return cfgs
+
+				ginkgo.It("should establish EVPN session and exchange Type-5 routes", func() {
+					peersConfig := setupEVPN(evpnL3ConfigTemplate)
+
+					ginkgo.By("Building FRRConfigurations with EVPN L3 VNI")
+					neighbors := neighborsWithEVPN(peersConfig)
+
+					for _, frrCfg := range l3VNIConfigs(neighbors) {
+						err := updater.Update(peersConfig.Secrets, frrCfg)
+						Expect(err).NotTo(HaveOccurred())
+					}
+
+					validateL3VNI()
+				})
+
+				ginkgo.It("should establish EVPN session and exchange Type-5 routes with L3 VNI config split across multiple FRRConfigurations", func() {
+					peersConfig := setupEVPN(evpnL3ConfigTemplate)
+
+					ginkgo.By("Building split FRRConfigurations: default-VRF router and VRF router separately")
+					neighbors := neighborsWithEVPN(peersConfig)
+
+					// Split each per-node config into two: one for the default-VRF router
+					// (neighbors + advertiseVNIs) and one for the VRF router (L3VNI).
+					for _, frrCfg := range l3VNIConfigs(neighbors) {
+						nodeSelector := frrCfg.Spec.NodeSelector
+						routers := frrCfg.Spec.BGP.Routers
+
+						cfgDefault := frrk8sv1beta1.FRRConfiguration{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      frrCfg.Name + "-default",
+								Namespace: k8s.FRRK8sNamespace,
+							},
+							Spec: frrk8sv1beta1.FRRConfigurationSpec{
+								NodeSelector: nodeSelector,
+								BGP: frrk8sv1beta1.BGPConfig{
+									Routers: []frrk8sv1beta1.Router{routers[0]},
+								},
+							},
+						}
+
+						cfgVRF := frrk8sv1beta1.FRRConfiguration{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      frrCfg.Name + "-vrf",
+								Namespace: k8s.FRRK8sNamespace,
+							},
+							Spec: frrk8sv1beta1.FRRConfigurationSpec{
+								NodeSelector: nodeSelector,
+								BGP: frrk8sv1beta1.BGPConfig{
+									Routers: []frrk8sv1beta1.Router{routers[1]},
+								},
+							},
+						}
+
+						err := updater.Update(peersConfig.Secrets, cfgDefault, cfgVRF)
+						Expect(err).NotTo(HaveOccurred())
+					}
+
+					validateL3VNI()
+				})
+			})
+		},
+		ginkgo.Entry("on IPV4 configurations with IPv4 peering and IPv4 advertising", ipfamily.IPv4, ipfamily.IPv4),
+		ginkgo.Entry("on DUALSTACK configurations with IPv4 peering and dualstack advertising", ipfamily.IPv4, ipfamily.DualStack),
+		ginkgo.Entry("on DUALSTACK configurations with IPv6 peering and dualstack advertising", ipfamily.IPv6, ipfamily.DualStack),
+	)
+
+	type evpnAllowAsInParams struct {
+		allowAsIn    frrk8sv1beta1.AllowAsInMode
+		expectRoutes bool
+	}
+
+	ginkgo.DescribeTable("on DUALSTACK configurations when exchanging routes with local AS in path",
+		func(p evpnAllowAsInParams) {
+			ebgpContainer := infra.FindContainer("ebgp-single-hop")
+			Expect(ebgpContainer).NotTo(BeNil(), "ebgp-single-hop container not found")
+			evpnFRRContainer = ebgpContainer
+			evpnCfg = evpnL3ConfigTemplate
+
+			ginkgo.By("Setting up EVPN networking infrastructure")
+			var err error
+			evpnInfra, err = infra.SetupEVPN(cs, ebgpContainer, evpnCfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Pairing external FRR with nodes (EVPN) with AS path prepend")
+			evpnPairCfg := frr.EVPNConfig{
+				L3VNI:           evpnL3VNI,
+				L3VRF:           evpnL3VRF,
+				AdvertiseFamily: ipfamily.DualStack,
+				PrependASN:      infra.FRRK8sASN,
+			}
+			err = frr.PairWithNodesForEVPN(ebgpContainer, cs, evpnPairCfg, ipfamily.IPv4)
+			Expect(err).NotTo(HaveOccurred())
+
+			ginkgo.By("Building FRRConfigurations with EVPN L3 VNI")
+			frrs := []*frrcontainer.FRR{ebgpContainer}
+			peersConfig := config.PeersForContainers(frrs, ipfamily.IPv4)
+			neighbors := config.NeighborsFromPeers(peersConfig.PeersV4, peersConfig.PeersV6)
+			for i := range neighbors {
+				neighbors[i].AddressFamilies = []frrk8sv1beta1.AddressFamily{"unicast", "evpn"}
+				if p.allowAsIn != "" {
+					neighbors[i].AllowAsIn = p.allowAsIn
+				}
 			}
 
-			ginkgo.It("should advertise type-5 prefixes via L3 VNI", func() {
-				peersConfig := setupEVPN(evpnL3ConfigTemplate)
-
-				ginkgo.By("Building FRRConfigurations with EVPN L3 VNI")
-				neighbors := neighborsWithEVPN(peersConfig)
-
-				for _, frrCfg := range l3VNIConfigs(neighbors) {
-					err := updater.Update(peersConfig.Secrets, frrCfg)
-					Expect(err).NotTo(HaveOccurred())
-				}
-
-				validateL3VNI()
-			})
-
-			ginkgo.It("should work with L3 VNI config split across multiple FRRConfigurations", func() {
-				peersConfig := setupEVPN(evpnL3ConfigTemplate)
-
-				ginkgo.By("Building split FRRConfigurations: default-VRF router and VRF router separately")
-				neighbors := neighborsWithEVPN(peersConfig)
-
-				// Split each per-node config into two: one for the default-VRF router
-				// (neighbors + advertiseVNIs) and one for the VRF router (L3VNI).
-				for _, frrCfg := range l3VNIConfigs(neighbors) {
-					nodeSelector := frrCfg.Spec.NodeSelector
-					routers := frrCfg.Spec.BGP.Routers
-
-					cfgDefault := frrk8sv1beta1.FRRConfiguration{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      frrCfg.Name + "-default",
-							Namespace: k8s.FRRK8sNamespace,
-						},
-						Spec: frrk8sv1beta1.FRRConfigurationSpec{
-							NodeSelector: nodeSelector,
-							BGP: frrk8sv1beta1.BGPConfig{
-								Routers: []frrk8sv1beta1.Router{routers[0]},
+			for _, node := range nodes {
+				frrCfg := frrk8sv1beta1.FRRConfiguration{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("test-evpn-allowasin-%s", node.Name),
+						Namespace: k8s.FRRK8sNamespace,
+					},
+					Spec: frrk8sv1beta1.FRRConfigurationSpec{
+						NodeSelector: metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								"kubernetes.io/hostname": node.Name,
 							},
 						},
-					}
-
-					cfgVRF := frrk8sv1beta1.FRRConfiguration{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      frrCfg.Name + "-vrf",
-							Namespace: k8s.FRRK8sNamespace,
-						},
-						Spec: frrk8sv1beta1.FRRConfigurationSpec{
-							NodeSelector: nodeSelector,
-							BGP: frrk8sv1beta1.BGPConfig{
-								Routers: []frrk8sv1beta1.Router{routers[1]},
+						BGP: frrk8sv1beta1.BGPConfig{
+							Routers: []frrk8sv1beta1.Router{
+								{
+									ASN:       infra.FRRK8sASN,
+									Neighbors: neighbors,
+									EVPN: &frrk8sv1beta1.EVPNConfig{
+										AdvertiseVNIs: ptr.To(frrk8sv1beta1.VNIAdvertisementAll),
+									},
+								},
+								{
+									ASN: infra.FRRK8sASN,
+									VRF: evpnL3VRF,
+									EVPN: &frrk8sv1beta1.EVPNConfig{
+										L3VNI: &frrk8sv1beta1.L3VNI{
+											VNI: evpnL3VNI,
+											VNIProperties: frrk8sv1beta1.VNIProperties{
+												RD: frrk8sv1beta1.RouteDistinguisher(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnL3VNI)),
+												ImportRTs: []frrk8sv1beta1.ImportRouteTarget{
+													frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnL3VNI)),
+													frrk8sv1beta1.ImportRouteTarget(fmt.Sprintf("%d:%d", ebgpContainer.RouterConfig.ASN, evpnL3VNI)),
+												},
+												ExportRTs: []frrk8sv1beta1.ExportRouteTarget{frrk8sv1beta1.ExportRouteTarget(fmt.Sprintf("%d:%d", infra.FRRK8sASN, evpnL3VNI))},
+											},
+											AdvertisePrefixes: []frrk8sv1beta1.AdvertisePrefixType{"unicast"},
+										},
+									},
+								},
 							},
 						},
-					}
-
-					err := updater.Update(peersConfig.Secrets, cfgDefault, cfgVRF)
-					Expect(err).NotTo(HaveOccurred())
+					},
 				}
+				err := updater.Update(peersConfig.Secrets, frrCfg)
+				Expect(err).NotTo(HaveOccurred())
+			}
 
-				validateL3VNI()
-			})
-		})
-	},
-	ginkgo.Entry("on IPV4 configurations with IPv4 peering and IPv4 advertising", ipfamily.IPv4, ipfamily.IPv4),
-	ginkgo.Entry("on DUALSTACK configurations with IPv4 peering and dualstack advertising", ipfamily.IPv4, ipfamily.DualStack),
-	ginkgo.Entry("on DUALSTACK configurations with IPv6 peering and dualstack advertising", ipfamily.IPv6, ipfamily.DualStack),
-)
+			ginkgo.By("Validating BGP sessions are established")
+			ValidateFRRPeeredWithNodes(nodes, ebgpContainer, ipfamily.IPv4)
+
+			pods, err := k8s.FRRK8sPods(cs)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedRoutes := map[string]string{}
+			for _, prefix := range evpnInfra.L3PrefixForFamily(ebgpContainer.Name, ipfamily.DualStack) {
+				expectedRoutes[prefix] = ebgpContainer.Ipv4
+			}
+
+			if p.expectRoutes {
+				ginkgo.By("Validating pods received the EVPN type-5 routes with local AS in path")
+				for _, pod := range pods {
+					Eventually(func() error {
+						return frr.ForPod(pod).HasEVPNType5Routes(expectedRoutes)
+					}, 30*time.Second, time.Second).ShouldNot(HaveOccurred(),
+						"EVPN type-5 routes not found on pod %s", pod.Name)
+				}
+			} else {
+				ginkgo.By("Validating pods rejected the EVPN type-5 routes with local AS in path")
+				for _, pod := range pods {
+					Consistently(func() error {
+						return frr.ForPod(pod).HasEVPNType5Routes(expectedRoutes)
+					}, 30*time.Second, time.Second).Should(HaveOccurred(),
+						"EVPN type-5 routes unexpectedly found on pod %s", pod.Name)
+				}
+			}
+		},
+		ginkgo.Entry("routes should be accepted with AllowAsIn origin", evpnAllowAsInParams{
+			allowAsIn:    frrk8sv1beta1.AllowAsInOrigin,
+			expectRoutes: true,
+		}),
+		ginkgo.Entry("routes should be rejected without AllowAsIn", evpnAllowAsInParams{
+			expectRoutes: false,
+		}),
+	)
+})
 
 func expectedL2VNIRoutes(frrk8sPods []*corev1.Pod) (map[string]string, error) {
 	routes := make(map[string]string, len(frrk8sPods))

--- a/internal/controller/api_to_config.go
+++ b/internal/controller/api_to_config.go
@@ -206,6 +206,7 @@ func neighborToFRR(n v1beta1.Neighbor, prefixesInRouter []string, alwaysBlock []
 		VRFName:         routerVRF,
 		AlwaysBlock:     alwaysBlock,
 		AddressFamilies: toStringSlice(n.AddressFamilies),
+		AllowAsIn:       string(n.AllowAsIn),
 	}
 
 	res.HoldTime, res.KeepaliveTime, err = parseTimers(n.HoldTime, n.KeepaliveTime)

--- a/internal/controller/frrconfiguration_crd_validation_test.go
+++ b/internal/controller/frrconfiguration_crd_validation_test.go
@@ -515,6 +515,51 @@ var _ = Describe("CRD validation", func() {
 					},
 				},
 			}),
+			Entry("neighbor with allowAsIn 3", &v1beta1.FRRConfiguration{
+				ObjectMeta: ctrl.ObjectMeta{Name: "test-allowasin-3", Namespace: "default"},
+				Spec: v1beta1.FRRConfigurationSpec{
+					BGP: v1beta1.BGPConfig{
+						Routers: []v1beta1.Router{{
+							ASN: 65000,
+							Neighbors: []v1beta1.Neighbor{{
+								ASN:       65001,
+								Address:   "192.0.2.1",
+								AllowAsIn: "3",
+							}},
+						}},
+					},
+				},
+			}),
+			Entry("neighbor with allowAsIn origin", &v1beta1.FRRConfiguration{
+				ObjectMeta: ctrl.ObjectMeta{Name: "test-allowasin-origin", Namespace: "default"},
+				Spec: v1beta1.FRRConfigurationSpec{
+					BGP: v1beta1.BGPConfig{
+						Routers: []v1beta1.Router{{
+							ASN: 65000,
+							Neighbors: []v1beta1.Neighbor{{
+								ASN:       65001,
+								Address:   "192.0.2.1",
+								AllowAsIn: v1beta1.AllowAsInOrigin,
+							}},
+						}},
+					},
+				},
+			}),
+			Entry("neighbor with allowAsIn none", &v1beta1.FRRConfiguration{
+				ObjectMeta: ctrl.ObjectMeta{Name: "test-allowasin-none", Namespace: "default"},
+				Spec: v1beta1.FRRConfigurationSpec{
+					BGP: v1beta1.BGPConfig{
+						Routers: []v1beta1.Router{{
+							ASN: 65000,
+							Neighbors: []v1beta1.Neighbor{{
+								ASN:       65001,
+								Address:   "192.0.2.1",
+								AllowAsIn: v1beta1.AllowAsInNone,
+							}},
+						}},
+					},
+				},
+			}),
 		)
 	})
 })

--- a/internal/controller/merge.go
+++ b/internal/controller/merge.go
@@ -5,6 +5,7 @@ package controller
 import (
 	"fmt"
 	"slices"
+	"strconv"
 
 	v1beta1 "github.com/metallb/frr-k8s/api/v1beta1"
 	"github.com/metallb/frr-k8s/internal/frr"
@@ -95,6 +96,10 @@ func mergeIntoNeighbor(dest, src *frr.NeighborConfig) error {
 	}
 	dest.Incoming = mergeAllowedIn(dest.Incoming, src.Incoming)
 	dest.AddressFamilies = sets.List(sets.New(append(dest.AddressFamilies, src.AddressFamilies...)...))
+	dest.AllowAsIn, err = mergeAllowAsIn(dest.AllowAsIn, src.AllowAsIn)
+	if err != nil {
+		return fmt.Errorf("could not merge allowAsIn for neighbor %s vrf %s, err: %w", src.Addr, src.VRFName, err)
+	}
 
 	cleanNeighborDefaults(dest)
 
@@ -150,6 +155,45 @@ func mergeNextHop(curr, toMerge string) (string, error) {
 		return curr, nil
 	}
 	return "", fmt.Errorf("multiple next hops (%s != %s) specified", curr, toMerge)
+}
+
+// mergeAllowAsIn merges two AllowAsIn values for the same neighbor.
+// Empty values yield to the other. "none" explicitly prevents any other
+// non-empty value from enabling allowas-in. Any other combination of
+// values resolves to the least restrictive.
+// Restrictiveness order: none, "", origin, 1, 2, ..., 10.
+func mergeAllowAsIn(a, b string) (string, error) {
+	if a == "" {
+		return b, nil
+	}
+	if b == "" {
+		return a, nil
+	}
+	if a == b {
+		return a, nil
+	}
+	if a == string(v1beta1.AllowAsInNone) || b == string(v1beta1.AllowAsInNone) {
+		return "", fmt.Errorf("conflicting allowAsIn values: %q and %q are incompatible", a, b)
+	}
+	return leastRestrictiveAllowAsIn(a, b), nil
+}
+
+// leastRestrictiveAllowAsIn returns the least restrictive of two non-empty,
+// non-none AllowAsIn values. "origin" is more restrictive than any numeric value;
+// between two numeric values the higher one wins.
+func leastRestrictiveAllowAsIn(a, b string) string {
+	aNum, aIsNum := strconv.Atoi(a)
+	bNum, bIsNum := strconv.Atoi(b)
+	if aIsNum != nil {
+		return b // a is "origin", b is numeric (less restrictive)
+	}
+	if bIsNum != nil {
+		return a // b is "origin", a is numeric (less restrictive)
+	}
+	if aNum >= bNum {
+		return a
+	}
+	return b
 }
 
 func mergeLocalPrefPrefixLists(curr, toMerge []frr.LocalPrefPrefixList) []frr.LocalPrefPrefixList {

--- a/internal/controller/merge_test.go
+++ b/internal/controller/merge_test.go
@@ -1476,6 +1476,240 @@ func TestMergeNeighbors(t *testing.T) {
 			},
 			err: fmt.Errorf("multiple localASNs specified for %s", "65040@192.0.1.20"),
 		},
+		{
+			name: "AllowAsIn: empty merges with numeric",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      "65040",
+					Addr:     "192.0.1.20",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+				},
+			},
+			expected: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+					Outgoing:  frr.AllowedOut{},
+					Incoming:  frr.AllowedIn{},
+				},
+			},
+		},
+		{
+			name: "AllowAsIn: both same numeric",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+				},
+			},
+			expected: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+					Outgoing:  frr.AllowedOut{},
+					Incoming:  frr.AllowedIn{},
+				},
+			},
+		},
+		{
+			name: "AllowAsIn: different numerics merge to least restrictive",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "7",
+				},
+			},
+			expected: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "7",
+					Outgoing:  frr.AllowedOut{},
+					Incoming:  frr.AllowedIn{},
+				},
+			},
+		},
+		{
+			name: "AllowAsIn: origin and numeric merge to numeric",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "origin",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+				},
+			},
+			expected: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+					Outgoing:  frr.AllowedOut{},
+					Incoming:  frr.AllowedIn{},
+				},
+			},
+		},
+		{
+			name: "AllowAsIn: none merges with empty",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "none",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily: ipfamily.IPv4,
+					Name:     "65040@192.0.1.20",
+					ASN:      "65040",
+					Addr:     "192.0.1.20",
+				},
+			},
+			expected: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "none",
+					Outgoing:  frr.AllowedOut{},
+					Incoming:  frr.AllowedIn{},
+				},
+			},
+		},
+		{
+			name: "AllowAsIn: both none",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "none",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "none",
+				},
+			},
+			expected: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "none",
+					Outgoing:  frr.AllowedOut{},
+					Incoming:  frr.AllowedIn{},
+				},
+			},
+		},
+		{
+			name: "AllowAsIn: none and numeric are incompatible",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "none",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "3",
+				},
+			},
+			err: fmt.Errorf("conflicting allowAsIn values: %q and %q are incompatible", "none", "3"),
+		},
+		{
+			name: "AllowAsIn: none and origin are incompatible",
+			curr: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "none",
+				},
+			},
+			toMerge: []*frr.NeighborConfig{
+				{
+					IPFamily:  ipfamily.IPv4,
+					Name:      "65040@192.0.1.20",
+					ASN:       "65040",
+					Addr:      "192.0.1.20",
+					AllowAsIn: "origin",
+				},
+			},
+			err: fmt.Errorf("conflicting allowAsIn values: %q and %q are incompatible", "none", "origin"),
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/frr/config.go
+++ b/internal/frr/config.go
@@ -89,6 +89,7 @@ type NeighborConfig struct {
 	Outgoing        AllowedOut
 	AlwaysBlock     []IncomingFilter
 	AddressFamilies []string
+	AllowAsIn       string
 }
 
 func (n *NeighborConfig) ID() string {

--- a/internal/frr/frr_test.go
+++ b/internal/frr/frr_test.go
@@ -923,6 +923,177 @@ func TestSingleSessionWithLocalASN(t *testing.T) {
 	testCheckConfigFile(t)
 }
 
+func TestSingleSessionWithAllowAsIn3(t *testing.T) {
+	testSetup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	frr := testNewFRR(t, ctx)
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily:  ipfamily.IPv4,
+						ASN:       "65001",
+						Addr:      "192.168.1.2",
+						AllowAsIn: "3",
+					},
+				},
+			},
+		},
+		Loglevel: LevelFrom(logging.LevelInfo),
+	}
+
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionWithAllowAsInOrigin(t *testing.T) {
+	testSetup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	frr := testNewFRR(t, ctx)
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily:  ipfamily.IPv4,
+						ASN:       "65001",
+						Addr:      "192.168.1.2",
+						AllowAsIn: "origin",
+					},
+				},
+			},
+		},
+		Loglevel: LevelFrom(logging.LevelInfo),
+	}
+
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionWithAllowAsInNone(t *testing.T) {
+	testSetup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	frr := testNewFRR(t, ctx)
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily:  ipfamily.IPv4,
+						ASN:       "65001",
+						Addr:      "192.168.1.2",
+						AllowAsIn: "none",
+					},
+				},
+			},
+		},
+		Loglevel: LevelFrom(logging.LevelInfo),
+	}
+
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestSingleSessionDualStackWithAllowAsIn(t *testing.T) {
+	testSetup(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	frr := testNewFRR(t, ctx)
+
+	config := Config{
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily:  ipfamily.DualStack,
+						ASN:       "65001",
+						Addr:      "192.168.1.2",
+						AllowAsIn: "3",
+					},
+				},
+			},
+		},
+		Loglevel: LevelFrom(logging.LevelInfo),
+	}
+
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
+func TestEVPNWithAllowAsIn(t *testing.T) {
+	testSetup(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	frr := testNewFRR(t, ctx)
+	defer cancel()
+
+	config := Config{
+		Loglevel: LevelFrom(logging.LevelInfo),
+		Routers: []*RouterConfig{
+			{
+				MyASN: 65000,
+				Neighbors: []*NeighborConfig{
+					{
+						IPFamily:        ipfamily.IPv4,
+						ASN:             "65001",
+						Addr:            "192.168.1.2",
+						AddressFamilies: []string{"unicast", "evpn"},
+						AllowAsIn:       "3",
+						Outgoing: AllowedOut{
+							PrefixesV4: []string{"192.169.1.0/24"},
+							PrefixesV6: []string{},
+						},
+					},
+				},
+				IPV4Prefixes: []string{"192.169.1.0/24"},
+				EVPN: &EVPNConfig{
+					AdvertiseVNIs: ptr.To("All"),
+				},
+			},
+		},
+	}
+	err := frr.ApplyConfig(&config)
+	if err != nil {
+		t.Fatalf("Failed to apply config: %s", err)
+	}
+
+	testCheckConfigFile(t)
+}
+
 func TestMultipleRoutersImportVRFs(t *testing.T) {
 	testSetup(t)
 

--- a/internal/frr/templates/evpn.tmpl
+++ b/internal/frr/templates/evpn.tmpl
@@ -9,6 +9,9 @@
   {{- $peer = .Iface }}
 {{- end }}
     neighbor {{$peer}} activate
+{{- if and (ne .AllowAsIn "") (ne .AllowAsIn "none") }}
+    neighbor {{$peer}} allowas-in {{.AllowAsIn}}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/internal/frr/templates/neighboripfamily.tmpl
+++ b/internal/frr/templates/neighboripfamily.tmpl
@@ -10,6 +10,9 @@
     neighbor {{$peer}} activate
     neighbor {{$peer}} route-map {{.ID}}-in in
     neighbor {{$peer}} route-map {{.ID}}-out out
+{{- if and (ne .AllowAsIn "") (ne .AllowAsIn "none") }}
+    neighbor {{$peer}} allowas-in {{.AllowAsIn}}
+{{- end }}
   exit-address-family
 {{- end -}}
 {{if activateNeighborFor "ipv6" .IPFamily .AddressFamilies }}
@@ -17,6 +20,9 @@
     neighbor {{$peer}} activate
     neighbor {{$peer}} route-map {{.ID}}-in in
     neighbor {{$peer}} route-map {{.ID}}-out out
+{{- if and (ne .AllowAsIn "") (ne .AllowAsIn "none") }}
+    neighbor {{$peer}} allowas-in {{.AllowAsIn}}
+{{- end }}
   exit-address-family
 {{- end -}}
 {{- end -}}

--- a/internal/frr/testdata/TestEVPNWithAllowAsIn.golden
+++ b/internal/frr/testdata/TestEVPNWithAllowAsIn.golden
@@ -1,0 +1,60 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 192.168.1.2-allowed-ipv4 seq 1 permit 192.169.1.0/24
+
+
+ipv6 prefix-list 192.168.1.2-allowed-ipv6 seq 1 deny any
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-allowed-ipv4
+
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-allowed-ipv6
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  neighbor 192.168.1.2 remote-as 65001
+  
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+    neighbor 192.168.1.2 allowas-in 3
+  exit-address-family
+  address-family ipv4 unicast
+    network 192.169.1.0/24
+  exit-address-family
+
+  address-family l2vpn evpn
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 allowas-in 3
+    advertise-all-vni
+  exit-address-family
+
+

--- a/internal/frr/testdata/TestSingleSessionDualStackWithAllowAsIn.golden
+++ b/internal/frr/testdata/TestSingleSessionDualStackWithAllowAsIn.golden
@@ -1,0 +1,56 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 192.168.1.2-allowed-ipv4 seq 1 deny any
+
+
+ipv6 prefix-list 192.168.1.2-allowed-ipv6 seq 1 deny any
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-allowed-ipv4
+
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-allowed-ipv6
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-dual seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-dual seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-dual
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-dual
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  neighbor 192.168.1.2 remote-as 65001
+  
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+    neighbor 192.168.1.2 allowas-in 3
+  exit-address-family
+  address-family ipv6 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+    neighbor 192.168.1.2 allowas-in 3
+  exit-address-family
+

--- a/internal/frr/testdata/TestSingleSessionWithAllowAsIn3.golden
+++ b/internal/frr/testdata/TestSingleSessionWithAllowAsIn3.golden
@@ -1,0 +1,50 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 192.168.1.2-allowed-ipv4 seq 1 deny any
+
+
+ipv6 prefix-list 192.168.1.2-allowed-ipv6 seq 1 deny any
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-allowed-ipv4
+
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-allowed-ipv6
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  neighbor 192.168.1.2 remote-as 65001
+  
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+    neighbor 192.168.1.2 allowas-in 3
+  exit-address-family
+

--- a/internal/frr/testdata/TestSingleSessionWithAllowAsInNone.golden
+++ b/internal/frr/testdata/TestSingleSessionWithAllowAsInNone.golden
@@ -1,0 +1,49 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 192.168.1.2-allowed-ipv4 seq 1 deny any
+
+
+ipv6 prefix-list 192.168.1.2-allowed-ipv6 seq 1 deny any
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-allowed-ipv4
+
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-allowed-ipv6
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  neighbor 192.168.1.2 remote-as 65001
+  
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+  exit-address-family
+

--- a/internal/frr/testdata/TestSingleSessionWithAllowAsInOrigin.golden
+++ b/internal/frr/testdata/TestSingleSessionWithAllowAsInOrigin.golden
@@ -1,0 +1,50 @@
+log stdout informational
+log timestamp precision 3
+hostname dummyhostname
+ip nht resolve-via-default
+ipv6 nht resolve-via-default
+
+
+
+ip prefix-list 192.168.1.2-allowed-ipv4 seq 1 deny any
+
+
+ipv6 prefix-list 192.168.1.2-allowed-ipv6 seq 1 deny any
+
+route-map 192.168.1.2-out permit 1
+  match ip address prefix-list 192.168.1.2-allowed-ipv4
+
+route-map 192.168.1.2-out permit 2
+  match ipv6 address prefix-list 192.168.1.2-allowed-ipv6
+
+
+
+
+
+ip prefix-list 192.168.1.2-inpl-ipv4 seq 1 deny any
+
+ipv6 prefix-list 192.168.1.2-inpl-ipv4 seq 2 deny any
+route-map 192.168.1.2-in permit 3
+  match ip address prefix-list 192.168.1.2-inpl-ipv4
+route-map 192.168.1.2-in permit 4
+  match ipv6 address prefix-list 192.168.1.2-inpl-ipv4
+
+router bgp 65000
+  no bgp ebgp-requires-policy
+  no bgp network import-check
+  no bgp default ipv4-unicast
+  bgp graceful-restart preserve-fw-state
+
+  neighbor 192.168.1.2 remote-as 65001
+  
+  
+  
+  
+
+  address-family ipv4 unicast
+    neighbor 192.168.1.2 activate
+    neighbor 192.168.1.2 route-map 192.168.1.2-in in
+    neighbor 192.168.1.2 route-map 192.168.1.2-out out
+    neighbor 192.168.1.2 allowas-in origin
+  exit-address-family
+


### PR DESCRIPTION
Adds support for the BGP `allowas-in` neighbor directive via a new `AllowAsIn` field on the `Neighbor` configuration. This is useful in hub-and-spoke or route-leaking topologies where the same AS number may appear multiple times in the path.

/kind feature

  ### Values

  - `""` (empty, default) or `"none"`: routes with the local AS in the path are rejected.
  - `"origin"`: routes are accepted only if the local AS appears as the origin (last AS in the path).
  - `"1"-"10"`: routes are accepted with the local AS appearing as much as that many times in the path.

  The directive is applied to all enabled address families (ipv4/ipv6 unicast and l2vpn evpn).

  ### Merge behavior

  When multiple configurations target the same neighbor, `"none"` explicitly prevents any other configuration from enabling allowas-in. Any other combination of values resolves to the least restrictive.

  ## Changes

  - API: new `AllowAsInMode` enum type and `AllowAsIn` field on `Neighbor`
  - Templates: `allowas-in` directive rendered in `neighboripfamily.tmpl` and `evpn.tmpl`
  - Merge: `mergeAllowAsIn` implements the merge strategy
  - Tests: golden file tests (ipv4, ipv6 dual-stack, EVPN), merge tests, CRD validation tests
  - Generated: CRD manifests, Helm chart CRD, API docs
  


