### PR TITLE
fix(chart): honor scrapeAnnotations for metrics service

### DIFF
--- a/charts/frr-k8s/README.md
+++ b/charts/frr-k8s/README.md
@@ -77,7 +77,7 @@ Kubernetes: `>= 1.19.0-0`
 | nameOverride | string | `""` | String to override the default chart name. |
 | prometheus.namespace | string | `""` | The namespace where Prometheus is deployed. Required when ".Values.prometheus.rbacPrometheus == true" and "prometheus.serviceMonitor.enabled=true". |
 | prometheus.rbacPrometheus | bool | `false` | Give Prometheus permission to scrape metallb's namespace. |
-| prometheus.scrapeAnnotations | bool | `false` | Add Prometheus metric auto-collection annotations to pods. |
+| prometheus.scrapeAnnotations | bool | `false` | Add Prometheus metric auto-collection annotations to the metrics Service. |
 | prometheus.secureMetricsPort | int | `9140` | Port frr-k8s will listen on for secure metrics. |
 | prometheus.serviceAccount | string | `""` | The service account used by Prometheus. Required when ".Values.prometheus.rbacPrometheus == true" and "prometheus.serviceMonitor.enabled=true" |
 | prometheus.serviceMonitor.additionalLabels | object | `{}` | Additional labels to add to the ServiceMonitor. |

--- a/charts/frr-k8s/templates/service-monitor.yaml
+++ b/charts/frr-k8s/templates/service-monitor.yaml
@@ -69,11 +69,15 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+{{- if or .Values.prometheus.scrapeAnnotations .Values.prometheus.serviceMonitor.annotations }}
   annotations:
+  {{- if .Values.prometheus.scrapeAnnotations }}
     prometheus.io/scrape: "true"
+  {{- end }}
   {{- if .Values.prometheus.serviceMonitor.annotations }}
 {{ toYaml .Values.prometheus.serviceMonitor.annotations | indent 4 }}
   {{- end }}
+{{- end }}
   labels:
     name: {{ template "frrk8s.fullname" . }}-frr-k8s-monitor-service
   name: {{ template "frrk8s.fullname" . }}-frr-k8s-monitor-service

--- a/charts/frr-k8s/templates/service-monitor.yaml
+++ b/charts/frr-k8s/templates/service-monitor.yaml
@@ -68,15 +68,17 @@ spec:
 ---
 apiVersion: v1
 kind: Service
+{{- $serviceAnnotations := dict }}
+{{- if .Values.prometheus.serviceMonitor.annotations }}
+  {{- $_ := merge $serviceAnnotations .Values.prometheus.serviceMonitor.annotations }}
+{{- end }}
+{{- if .Values.prometheus.scrapeAnnotations }}
+  {{- $_ := set $serviceAnnotations "prometheus.io/scrape" "true" }}
+{{- end }}
 metadata:
-{{- if or .Values.prometheus.scrapeAnnotations .Values.prometheus.serviceMonitor.annotations }}
+{{- if $serviceAnnotations }}
   annotations:
-  {{- if .Values.prometheus.scrapeAnnotations }}
-    prometheus.io/scrape: "true"
-  {{- end }}
-  {{- if .Values.prometheus.serviceMonitor.annotations }}
-{{ toYaml .Values.prometheus.serviceMonitor.annotations | indent 4 }}
-  {{- end }}
+{{ toYaml $serviceAnnotations | indent 4 }}
 {{- end }}
   labels:
     name: {{ template "frrk8s.fullname" . }}-frr-k8s-monitor-service

--- a/charts/frr-k8s/values.yaml
+++ b/charts/frr-k8s/values.yaml
@@ -23,14 +23,14 @@ rbac:
 
 prometheus:
   # scrape annotations specifies whether to add Prometheus metric
-  # auto-collection annotations to pods. See
+  # auto-collection annotations to the metrics Service. See
   # https://github.com/prometheus/prometheus/blob/release-2.1/documentation/examples/prometheus-kubernetes.yml
   # for a corresponding Prometheus configuration. Alternatively, you
   # may want to use the Prometheus Operator
   # (https://github.com/coreos/prometheus-operator) for more powerful
   # monitoring configuration. If you use the Prometheus operator, this
   # can be left at false.
-  # -- Add Prometheus metric auto-collection annotations to pods.
+  # -- Add Prometheus metric auto-collection annotations to the metrics Service.
   scrapeAnnotations: false
 
   # -- Port frr-k8s will listen on for secure metrics.


### PR DESCRIPTION
**Is this a BUG FIX or a FEATURE ?**:

/kind bug

**What this PR does / why we need it**:

This PR makes the Helm chart add `prometheus.io/scrape: "true"` to the metrics Service only when `prometheus.scrapeAnnotations=true`.

Today, when `prometheus.serviceMonitor.enabled=true`, the chart always adds the scrape annotation to the metrics Service created for the ServiceMonitor. In Prometheus installations that use both ServiceMonitor discovery and annotation-based discovery, this can cause the same metrics endpoints to be scraped twice.

The chart already exposes `prometheus.scrapeAnnotations`, and `values.yaml` documents that it can be left disabled when using the Prometheus Operator. However, the Service template did not use this value for the generated metrics Service annotation.

This PR aligns the rendered Service with the existing value by making the annotation opt-in. It also updates the chart documentation for `prometheus.scrapeAnnotations` to say that the annotation is applied to the metrics Service, not to pods.

Fixed #463 

**Special notes for your reviewer**:

Validated with:

```sh
helm lint charts/frr-k8s
helm template test charts/frr-k8s --show-only templates/service-monitor.yaml --set prometheus.serviceMonitor.enabled=true
helm template test charts/frr-k8s --show-only templates/service-monitor.yaml --set prometheus.serviceMonitor.enabled=true --set prometheus.scrapeAnnotations=true
make verify-helm-docs-comments
git diff --check
```

**Release note**:

```release-note
Helm chart metrics Service annotations now honor prometheus.scrapeAnnotations, avoiding duplicate scrapes when ServiceMonitor is enabled.
```
