### PR TITLE
design: redistribute support

### DIFF
--- a/design/redistribute-support.md
+++ b/design/redistribute-support.md
@@ -1,0 +1,113 @@
+# Redistribution Support for FRRConfiguration
+
+## Summary
+
+This proposal adds route redistribution to the FRRConfiguration CRD.
+Users can advertise routes from a kernel routing table.
+The reachability decision stays in the kernel table.
+The CRD only bounds which prefixes may leave.
+
+## Motivation
+
+Some agents signal per-node state through kernel routes.
+Example: a health checker (kubevip) installs a /32 into table 198 while a local backend is healthy.
+FRR should advertise that route only while it exists.
+This gives automatic per-node withdrawal and ECMP across healthy nodes.
+
+Today the CRD cannot express this:
+
+1. `router.prefixes` renders unconditional `network` statements. This bypasses the gating.
+2. `toAdvertise.allowed.mode: all` only allows prefixes declared in `router.prefixes`. Redistributed routes are always filtered out on egress.
+
+The only workaround is `rawConfig`. It must append permits to the generated `<neighbor>-out` route-maps.
+That couples user config to internal naming and sequence numbers. It can silently break on frr-k8s upgrade.
+
+OpenShift's BGP-based VIP management plans to use this pattern in production and carries the fragile rawConfig today in the POC.
+
+### Goals
+
+- Advertise routes redistributed from a kernel table (`table-direct`).
+- Filter egress to an explicit prefix allow-list.
+- Compose with the generated per-neighbor route-maps. No raw config.
+
+### Non-Goals
+
+- Redistributing other protocols (connected, static, kernel, OSPF). The API leaves room for them.
+- Import policy or route modification (communities, med) for redistributed routes.
+- Managing the kernel table content. That is the user's agent's job.
+
+## Proposal
+
+### User Stories
+
+As a cluster administrator, I want to:
+
+1. Advertise a VIP only while my health-check agent keeps its route in a kernel table.
+2. Bound the advertisement to an explicit prefix list so nothing else can leak.
+3. Upgrade frr-k8s without my egress filters breaking.
+
+### API Changes
+
+Add a `redistribute` list to `Router`:
+
+```yaml
+apiVersion: frrk8s.metallb.io/v1beta1
+kind: FRRConfiguration
+metadata:
+  name: vip-advertisement
+spec:
+  bgp:
+    routers:
+    - asn: 64512
+      neighbors:
+      - address: 192.168.1.1
+        asn: 64513
+        toAdvertise:
+          allowed:
+            mode: all
+      redistribute:
+      - protocol: table-direct
+        table: 198
+        allowedPrefixes:
+        - 192.168.111.4/32
+        - 192.168.111.5/32
+```
+
+Fields:
+
+- `protocol`: only `table-direct` initially. Enum, extensible.
+- `table`: kernel table id. Required for `table-direct`.
+- `allowedPrefixes`: prefixes permitted to leave. Required. No implicit "all".
+
+### Generated FRR Configuration
+
+```
+ip import-table 198
+router bgp 64512
+ address-family ipv4 unicast
+  redistribute table-direct 198 route-map redistribute-198-ipv4
+route-map redistribute-198-ipv4 permit 1
+ match ip address prefix-list redistribute-198-allowed-ipv4
+route-map redistribute-198-ipv4 deny 2
+ip prefix-list redistribute-198-allowed-ipv4 seq 1 permit 192.168.111.4/32
+ip prefix-list redistribute-198-allowed-ipv4 seq 2 permit 192.168.111.5/32
+```
+
+Egress: the same `allowedPrefixes` are appended as permit entries to each neighbor's generated `-out` route-map.
+`toAdvertise` semantics for declared prefixes stay unchanged.
+
+Neighbors with `mode: all` also advertise redistributed routes.
+Neighbors with explicit `allowed.prefixes` do not, unless the prefixes overlap.
+
+Note: `zebra` needs `ip import-table <n>` for `redistribute table-direct <n>` to see the table.
+The renderer emits it automatically.
+
+## Alternatives Considered
+
+- **Keep rawConfig.** Fragile and defeats the purpose.
+- **CRD-declared prefixes (`network` statements).** Unconditional. Defeats health gating.
+
+## Test Plan
+
+- Unit: api_to_config coverage for the new stanza.
+- E2E: install route in table, expect advertisement; remove route, expect withdrawal; verify a non-allowed prefix in the table never leaves.

--- a/design/redistribute-support.md
+++ b/design/redistribute-support.md
@@ -107,6 +107,7 @@ IPv6 prefixes render the same under `address-family ipv6 unicast`, with `ipv6 pr
 
 Egress: for neighbors with `toAdvertise.allowed.mode: all`, the redistributed `allowedPrefixes` are appended to the neighbor's generated allowed prefix-lists (`ToAdvertisePrefixListV4`/`V6`).
 No extra route-map clauses.
+When the neighbor has no declared prefixes, the redistributed prefixes must replace the `deny any` placeholder entry, not follow it. Prefix-lists are first-match.
 Neighbor modifiers like `set ip next-hop` live in the main permit rule and apply uniformly.
 Neighbors with explicit `allowed.prefixes` are untouched. They advertise a redistributed prefix only if it is also in their own allow-list.
 `toAdvertise` semantics for declared prefixes stay unchanged.
@@ -117,9 +118,9 @@ Neighbors with explicit `allowed.prefixes` are untouched. They advertise a redis
 
 - Reject `table` outside 1-65535. This mirrors FRR's `redistribute table-direct (1-65535)`.
 - Reject empty `allowedPrefixes` or any invalid CIDR block within it.
-- Reject duplicate `table` entries within one router.
+- Reject duplicate `(protocol, table)` pairs within one router. Future table-less protocols are not affected.
 - Reject `redistribute` on VRF routers.
-- Merge across FRRConfigurations: union of `allowedPrefixes` per table.
+- Merge across FRRConfigurations: union of `allowedPrefixes` per router and table.
   Fail the merge if the same table is declared with different protocols.
 - The webhook's outgoing-prefix check (`validateOutgoingPrefixes`) must
   accept redistributed prefixes: the union of `redistribute.allowedPrefixes`
@@ -134,4 +135,6 @@ Neighbors with explicit `allowed.prefixes` are untouched. They advertise a redis
 ## Test Plan
 
 - Unit: api_to_config coverage for the new stanza.
+- Unit: neighbor modifiers (e.g. `set ip next-hop`) apply to redistributed prefixes.
 - E2E: install route in table, expect advertisement; remove route, expect withdrawal; verify a non-allowed prefix in the table never leaves.
+- E2E: dual-stack variant (mixed v4/v6 `allowedPrefixes`).

--- a/design/redistribute-support.md
+++ b/design/redistribute-support.md
@@ -35,6 +35,7 @@ OpenShift's BGP-based VIP management plans to use this pattern in production and
 - Redistributing other protocols (connected, static, kernel, OSPF). The API leaves room for them.
 - Import policy or route modification (communities, med) for redistributed routes.
 - Managing the kernel table content. That is the user's agent's job.
+- VRF routers. Deferred until FRR's per-VRF `import-table` semantics are verified and we actually need that.
 
 ## Proposal
 
@@ -88,12 +89,10 @@ A family with no prefixes renders nothing. No validation against neighbor famili
 
 ### Generated FRR Configuration
 
-Names are scoped by VRF and family: `redistribute-<vrf>-<table>-<family>`.
-Route-maps and prefix-lists are global in FRR.
-Scoping prevents collisions when different VRFs redistribute the same table id.
+Names are scoped by VRF and family: `redistribute-<vrf>-<table>-<family>`. Initially always `default`.
+The VRF placeholder future-proofs the naming for VRF support.
 
 ```
-ip import-table 198
 router bgp 64512
  address-family ipv4 unicast
   redistribute table-direct 198 route-map redistribute-default-198-ipv4
@@ -107,21 +106,22 @@ ip prefix-list redistribute-default-198-allowed-ipv4 seq 2 permit 192.168.111.5/
 IPv6 prefixes render the same under `address-family ipv6 unicast`, with `ipv6 prefix-list` and `-ipv6` names.
 
 Egress: the `allowedPrefixes` permits are appended **only** to the `-out` route-maps of neighbors with `toAdvertise.allowed.mode: all`.
-Neighbors with explicit `allowed.prefixes` are untouched.
-They advertise a redistributed prefix only if it is also in their own allow-list.
+Neighbors with explicit `allowed.prefixes` are untouched. They advertise a redistributed prefix only if it is also in their own allow-list.
 `toAdvertise` semantics for declared prefixes stay unchanged.
 
-Note: `zebra` needs `ip import-table <n>` for `redistribute table-direct <n>` to see the table.
-The renderer emits it automatically.
-The IPv6 zebra visibility path will be verified during implementation and covered by a dual-stack e2e.
+`table-direct` reads the kernel table directly. No `ip import-table` is needed.
 
 ### Validation
 
-- Reject `table` outside 1-252.
+- Reject `table` outside 1-65535. This mirrors FRR's `redistribute table-direct (1-65535)`.
 - Reject empty `allowedPrefixes`.
 - Reject duplicate `table` entries within one router.
-- The same table in different VRFs is legal. Scoped names keep it collision-free.
-- Merge across FRRConfigurations: union of `allowedPrefixes` per (vrf, table).
+- Reject `redistribute` on VRF routers.
+- Merge across FRRConfigurations: union of `allowedPrefixes` per table.
+- The webhook's outgoing-prefix check (`validateOutgoingPrefixes`) must
+  accept redistributed prefixes: the union of `redistribute.allowedPrefixes`
+  joins the router's known prefixes. Otherwise a `filtered` neighbor listing
+  a redistributed prefix is falsely rejected.
 
 ## Alternatives Considered
 

--- a/design/redistribute-support.md
+++ b/design/redistribute-support.md
@@ -35,7 +35,7 @@ OpenShift's BGP-based VIP management plans to use this pattern in production and
 - Redistributing other protocols (connected, static, kernel, OSPF). The API leaves room for them.
 - Import policy or route modification (communities, med) for redistributed routes.
 - Managing the kernel table content. That is the user's agent's job.
-- VRF routers. Deferred until FRR's per-VRF `import-table` semantics are verified and we actually need that.
+- VRF routers. Deferred we actually need that.
 
 ## Proposal
 

--- a/design/redistribute-support.md
+++ b/design/redistribute-support.md
@@ -79,28 +79,49 @@ Fields:
 - `table`: kernel table id. Required for `table-direct`.
 - `allowedPrefixes`: prefixes permitted to leave. Required. No implicit "all".
 
+### Dual-stack
+
+`allowedPrefixes` may mix IPv4 and IPv6. The renderer splits them by family.
+Each family gets its own route-map, prefix-list and `address-family` block.
+A family with no prefixes renders nothing. No validation against neighbor families is needed.
+`table-direct` supports both families in FRR.
+
 ### Generated FRR Configuration
+
+Names are scoped by VRF and family: `redistribute-<vrf>-<table>-<family>`.
+Route-maps and prefix-lists are global in FRR.
+Scoping prevents collisions when different VRFs redistribute the same table id.
 
 ```
 ip import-table 198
 router bgp 64512
  address-family ipv4 unicast
-  redistribute table-direct 198 route-map redistribute-198-ipv4
-route-map redistribute-198-ipv4 permit 1
- match ip address prefix-list redistribute-198-allowed-ipv4
-route-map redistribute-198-ipv4 deny 2
-ip prefix-list redistribute-198-allowed-ipv4 seq 1 permit 192.168.111.4/32
-ip prefix-list redistribute-198-allowed-ipv4 seq 2 permit 192.168.111.5/32
+  redistribute table-direct 198 route-map redistribute-default-198-ipv4
+route-map redistribute-default-198-ipv4 permit 1
+ match ip address prefix-list redistribute-default-198-allowed-ipv4
+route-map redistribute-default-198-ipv4 deny 2
+ip prefix-list redistribute-default-198-allowed-ipv4 seq 1 permit 192.168.111.4/32
+ip prefix-list redistribute-default-198-allowed-ipv4 seq 2 permit 192.168.111.5/32
 ```
 
-Egress: the same `allowedPrefixes` are appended as permit entries to each neighbor's generated `-out` route-map.
-`toAdvertise` semantics for declared prefixes stay unchanged.
+IPv6 prefixes render the same under `address-family ipv6 unicast`, with `ipv6 prefix-list` and `-ipv6` names.
 
-Neighbors with `mode: all` also advertise redistributed routes.
-Neighbors with explicit `allowed.prefixes` do not, unless the prefixes overlap.
+Egress: the `allowedPrefixes` permits are appended **only** to the `-out` route-maps of neighbors with `toAdvertise.allowed.mode: all`.
+Neighbors with explicit `allowed.prefixes` are untouched.
+They advertise a redistributed prefix only if it is also in their own allow-list.
+`toAdvertise` semantics for declared prefixes stay unchanged.
 
 Note: `zebra` needs `ip import-table <n>` for `redistribute table-direct <n>` to see the table.
 The renderer emits it automatically.
+The IPv6 zebra visibility path will be verified during implementation and covered by a dual-stack e2e.
+
+### Validation
+
+- Reject `table` outside 1-252.
+- Reject empty `allowedPrefixes`.
+- Reject duplicate `table` entries within one router.
+- The same table in different VRFs is legal. Scoped names keep it collision-free.
+- Merge across FRRConfigurations: union of `allowedPrefixes` per (vrf, table).
 
 ## Alternatives Considered
 

--- a/design/redistribute-support.md
+++ b/design/redistribute-support.md
@@ -79,6 +79,9 @@ Fields:
 - `protocol`: only `table-direct` initially. Enum, extensible.
 - `table`: kernel table id. Required for `table-direct`.
 - `allowedPrefixes`: prefixes permitted to leave. Required. No implicit "all".
+  Matching is exact: `192.168.111.0/24` matches only the /24 route itself, not
+  contained /32s. Range selectors (`le`/`ge`, as in `toReceive.allowed.prefixes`)
+  are a possible future extension.
 
 ### Dual-stack
 
@@ -89,7 +92,8 @@ A family with no prefixes renders nothing. No validation against neighbor famili
 
 ### Generated FRR Configuration
 
-Names are scoped by VRF and family: `redistribute-<vrf>-<table>-<family>`. Initially always `default`.
+Names are scoped by VRF and family: `redistribute-<vrf>-<table>-<family>`.
+An empty `vrf` field maps to the literal `default` (never an empty name segment). Initially always `default`.
 The VRF placeholder future-proofs the naming for VRF support.
 
 ```

--- a/design/redistribute-support.md
+++ b/design/redistribute-support.md
@@ -35,7 +35,7 @@ OpenShift's BGP-based VIP management plans to use this pattern in production and
 - Redistributing other protocols (connected, static, kernel, OSPF). The API leaves room for them.
 - Import policy or route modification (communities, med) for redistributed routes.
 - Managing the kernel table content. That is the user's agent's job.
-- VRF routers. Deferred we actually need that.
+- VRF routers. Deferred until FRR's per-VRF `table-direct` behavior is verified and we actually need that.
 
 ## Proposal
 
@@ -105,7 +105,9 @@ ip prefix-list redistribute-default-198-allowed-ipv4 seq 2 permit 192.168.111.5/
 
 IPv6 prefixes render the same under `address-family ipv6 unicast`, with `ipv6 prefix-list` and `-ipv6` names.
 
-Egress: the `allowedPrefixes` permits are appended **only** to the `-out` route-maps of neighbors with `toAdvertise.allowed.mode: all`.
+Egress: for neighbors with `toAdvertise.allowed.mode: all`, the redistributed `allowedPrefixes` are appended to the neighbor's generated allowed prefix-lists (`ToAdvertisePrefixListV4`/`V6`).
+No extra route-map clauses.
+Neighbor modifiers like `set ip next-hop` live in the main permit rule and apply uniformly.
 Neighbors with explicit `allowed.prefixes` are untouched. They advertise a redistributed prefix only if it is also in their own allow-list.
 `toAdvertise` semantics for declared prefixes stay unchanged.
 
@@ -114,11 +116,11 @@ Neighbors with explicit `allowed.prefixes` are untouched. They advertise a redis
 ### Validation
 
 - Reject `table` outside 1-65535. This mirrors FRR's `redistribute table-direct (1-65535)`.
-- Reject empty `allowedPrefixes`.
-- Reject invalid prefixes.
+- Reject empty `allowedPrefixes` or any invalid CIDR block within it.
 - Reject duplicate `table` entries within one router.
 - Reject `redistribute` on VRF routers.
 - Merge across FRRConfigurations: union of `allowedPrefixes` per table.
+  Fail the merge if the same table is declared with different protocols.
 - The webhook's outgoing-prefix check (`validateOutgoingPrefixes`) must
   accept redistributed prefixes: the union of `redistribute.allowedPrefixes`
   joins the router's known prefixes. Otherwise a `filtered` neighbor listing

--- a/design/redistribute-support.md
+++ b/design/redistribute-support.md
@@ -115,6 +115,7 @@ Neighbors with explicit `allowed.prefixes` are untouched. They advertise a redis
 
 - Reject `table` outside 1-65535. This mirrors FRR's `redistribute table-direct (1-65535)`.
 - Reject empty `allowedPrefixes`.
+- Reject invalid prefixes.
 - Reject duplicate `table` entries within one router.
 - Reject `redistribute` on VRF routers.
 - Merge across FRRConfigurations: union of `allowedPrefixes` per table.


### PR DESCRIPTION
<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

/kind design

**What this PR does / why we need it**:

We want ability for FRR to advertise rules dynamically coming from the kernel table. This enables a scenario of health checker installing routes into the kernel table and FRR announcing them when they exist and not announcing them when they do not.

The logic of health checker is completely up to the user's agent. FRR only consumes content of the kernel table.

**Special notes for your reviewer**:

Supersedes https://github.com/metallb/frr-k8s/issues/469

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
