### PR TITLE
tls: pass cipher suites even when tls version is 1.3

### DIFF
--- a/internal/tlsconfig/tlsopt.go
+++ b/internal/tlsconfig/tlsopt.go
@@ -18,10 +18,6 @@ import (
 // Curve preferences are specified as comma-separated numeric CurveID values
 // (see https://pkg.go.dev/crypto/tls#CurveID), matching the Kubernetes
 // --tls-curve-preferences flag format (kubernetes/kubernetes#137115).
-//
-// Returns an error if cipher suites are specified with TLS 1.3 minimum, since
-// Go's TLS 1.3 does not allow configuring cipher suites -- all TLS 1.3
-// ciphers are always enabled. See: https://github.com/golang/go/issues/29349
 func OptFor(cipherSuites, curvePreferences, minVersion string) (func(*tls.Config), error) {
 	ciphers, err := parseCipherSuites(cipherSuites)
 	if err != nil {
@@ -34,9 +30,6 @@ func OptFor(cipherSuites, curvePreferences, minVersion string) (func(*tls.Config
 	minVer, err := parseTLSVersion(minVersion)
 	if err != nil {
 		return nil, fmt.Errorf("parsing tls-min-version: %w", err)
-	}
-	if ciphers != nil && minVer == tls.VersionTLS13 {
-		return nil, fmt.Errorf("cipher suites cannot be configured with TLS 1.3")
 	}
 	return func(cfg *tls.Config) {
 		if ciphers != nil {

--- a/internal/tlsconfig/tlsopt_test.go
+++ b/internal/tlsconfig/tlsopt_test.go
@@ -160,10 +160,11 @@ func TestOptFor(t *testing.T) {
 			wantMinVersion:       tls.VersionTLS13,
 		},
 		{
-			name:         "rejects cipher suites with TLS 1.3",
-			cipherSuites: "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-			minVersion:   "VersionTLS13",
-			wantErrMsg:   "cipher suites cannot be configured with TLS 1.3",
+			name:             "cipher suites with TLS 1.3 accepted (Go ignores them)",
+			cipherSuites:     "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+			minVersion:       "VersionTLS13",
+			wantCipherSuites: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantMinVersion:   tls.VersionTLS13,
 		},
 		{
 			name:         "invalid cipher returns error",


### PR DESCRIPTION
We were too harsh by denying configurations for suites when tls min version is 1.3, as go itself does not deny them but rather ignores them.
Here we align with this approach.

<!-- Thanks for sending a pull request!
1. If this is your first time, please read the [contributing guide](https://metallb.universe.tf/community/#contributing)
2. For non-trivial pull requests, please [file an
   issue](https://github.com/metallb/metallb/issues/new) first, and get
   agreement that the change is a good idea, and a general guideline
   for how it should be implemented, before sending code. Large PRs
   that weren't first discussed and agreed upon in an issue won't be
   accepted.
3. If the PR fixes a particular bug, please include the words "Fixed
   #<issue number>" in the PR text, so that the bug auto-closes when
   the PR is merged.
-->

**Is this a BUG FIX or a FEATURE ?**:

> Uncomment only one, leave it on its own line:
>
/kind bug
> /kind cleanup
> /kind feature
> /kind design
> /kind flake
> /kind failing
> /kind documentation
> /kind regression

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If no release note is required, just write "NONE".
-->

```release-note
NONE
```
